### PR TITLE
Model filter and reader

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/OASFilter.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/OASFilter.java
@@ -49,7 +49,9 @@ public interface OASFilter {
      * @param pathItem the current PathItem element
      * @return the PathItem to be used or null 
      */
-    PathItem filterPathItem(PathItem pathItem);
+    default PathItem filterPathItem(PathItem pathItem){
+        return pathItem;
+    }
     
     /**
      * Allows filtering of a particular Operation.  Implementers of this method can choose to update the given Operation,
@@ -58,7 +60,9 @@ public interface OASFilter {
      * @param operation the current Operation element
      * @return the Operation to be used or null 
      */
-    Operation filterOperation(Operation operation);
+    default Operation filterOperation(Operation operation) {
+        return operation;
+    }
     
     /**
      * Allows filtering of a particular Parameter.  Implementers of this method can choose to update the given Parameter,
@@ -67,7 +71,9 @@ public interface OASFilter {
      * @param parameter the current Parameter element
      * @return the Parameter to be used or null 
      */
-    Parameter filterParameter(Parameter parameter);
+    default Parameter filterParameter(Parameter parameter) {
+        return parameter;
+    }
     
     /**
      * Allows filtering of a particular Header.  Implementers of this method can choose to update the given Header,
@@ -76,7 +82,9 @@ public interface OASFilter {
      * @param header the current Header element
      * @return the Header to be used or null 
      */
-    Header filterHeader(Header header);
+    default Header filterHeader(Header header) {
+        return header;
+    }
     
     /**
      * Allows filtering of a particular RequestBody.  Implementers of this method can choose to update the given RequestBody,
@@ -85,7 +93,9 @@ public interface OASFilter {
      * @param requestBody the current RequestBody element
      * @return the RequestBody to be used or null 
      */
-    RequestBody filterRequestBody(RequestBody requestBody);
+    default RequestBody filterRequestBody(RequestBody requestBody) {
+        return requestBody;
+    }
     
     /**
      * Allows filtering of a particular APIResponse.  Implementers of this method can choose to update the given APIResponse,
@@ -94,7 +104,9 @@ public interface OASFilter {
      * @param apiResponse the current APIResponse element
      * @return the APIResponse to be used or null 
      */
-    APIResponse filterAPIResponse(APIResponse apiResponse);
+    default APIResponse filterAPIResponse(APIResponse apiResponse) {
+        return apiResponse;
+    }
     
     /**
      * Allows filtering of a particular Schema.  Implementers of this method can choose to update the given Schema,
@@ -103,7 +115,9 @@ public interface OASFilter {
      * @param schema the current Schema element
      * @return the Schema to be used or null 
      */
-    Schema<?> filterSchema(Schema<?> schema);
+    default Schema<?> filterSchema(Schema<?> schema) {
+        return schema;
+    }
     
     /**
      * Allows filtering of a particular SecurityScheme.  Implementers of this method can choose to update the given SecurityScheme,
@@ -112,7 +126,9 @@ public interface OASFilter {
      * @param securityScheme the current SecurityScheme element
      * @return the SecurityScheme to be used or null 
      */
-    SecurityScheme filterSecurityScheme(SecurityScheme securityScheme);
+    default SecurityScheme filterSecurityScheme(SecurityScheme securityScheme) {
+        return securityScheme;
+    }
     
     /**
      * Allows filtering of a particular Server.  Implementers of this method can choose to update the given Server,
@@ -121,7 +137,9 @@ public interface OASFilter {
      * @param server the current Server element
      * @return the Server to be used or null 
      */
-    Server filterServer(Server server);
+    default Server filterServer(Server server) {
+        return server;
+    }
     
     /**
      * Allows filtering of a particular Tag.  Implementers of this method can choose to update the given Tag,
@@ -130,7 +148,9 @@ public interface OASFilter {
      * @param tag the current Tag element
      * @return the Tag to be used or null 
      */
-    Tag filterTag(Tag tag);
+    default Tag filterTag(Tag tag) {
+        return tag;
+    }
     
     /**
      * Allows filtering of a particular Link.  Implementers of this method can choose to update the given Link,
@@ -139,7 +159,9 @@ public interface OASFilter {
      * @param link the current Link element
      * @return the Link to be used or null 
      */
-    Link filterLink(Link link);
+    default Link filterLink(Link link) {
+        return link;
+    }
     
     /**
      * Allows filtering of a particular Callback.  Implementers of this method can choose to update the given Callback,
@@ -148,7 +170,9 @@ public interface OASFilter {
      * @param callback the current Callback element
      * @return the Callback to be used or null 
      */
-    Callback filterCallback(Callback callback);
+    default Callback filterCallback(Callback callback) {
+        return callback;
+    }
     
     /**
      * Allows filtering of the singleton OpenAPI element.  Implementers of this method can choose to update this element, or
@@ -158,5 +182,5 @@ public interface OASFilter {
      * 
      * @param openAPI the current OpenAPI element
      */
-    void filterOpenAPI(OpenAPI openAPI);
+    default void filterOpenAPI(OpenAPI openAPI) {}
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/OASFilter.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/OASFilter.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.openapi;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.callbacks.Callback;
+import org.eclipse.microprofile.openapi.models.headers.Header;
+import org.eclipse.microprofile.openapi.models.links.Link;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.eclipse.microprofile.openapi.models.parameters.Parameter;
+import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.models.responses.APIResponse;
+import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
+import org.eclipse.microprofile.openapi.models.servers.Server;
+import org.eclipse.microprofile.openapi.models.tags.Tag;
+
+/**
+ * This interface allows application developers to filter different parts of the OpenAPI model tree.
+ * 
+ * A common scenario is to dynamically augment (update or remove) OpenAPI elements based on the environment
+ * that the application is currently in.  
+ * 
+ * The registration of this filter is controlled by setting the key <b>mp.openapi.filter</b> using
+ * one of the configuration sources specified in <a href="https://github.com/eclipse/microprofile-config">MicroProfile Config</a>.
+ * The value is the fully qualified name of the filter implementation, which needs to be visible to the application's classloader.
+ *
+ */
+public interface OASFilter {    
+	
+    /**
+     * Allows filtering of a particular PathItem.  Implementers of this method can choose to update the given PathItem,
+     * pass it back as-is, or return null if removing this PathItem.
+     * 
+     * @return the PathItem to be used or null 
+     */
+    PathItem filterPathItem(PathItem pathItem);
+    
+    /**
+     * Allows filtering of a particular Operation.  Implementers of this method can choose to update the given Operation,
+     * pass it back as-is, or return null if removing this Operation.
+     * 
+     * @return the Operation to be used or null 
+     */
+    Operation filterOperation(Operation operation);
+    
+    /**
+     * Allows filtering of a particular Parameter.  Implementers of this method can choose to update the given Parameter,
+     * pass it back as-is, or return null if removing this Parameter.
+     * 
+     * @return the Parameter to be used or null 
+     */
+    Parameter filterParameter(Parameter parameter);
+    
+    /**
+     * Allows filtering of a particular Header.  Implementers of this method can choose to update the given Header,
+     * pass it back as-is, or return null if removing this Header.
+     * 
+     * @return the Header to be used or null 
+     */
+    Header filterHeader(Header header);
+    
+    /**
+     * Allows filtering of a particular RequestBody.  Implementers of this method can choose to update the given RequestBody,
+     * pass it back as-is, or return null if removing this RequestBody.
+     * 
+     * @return the RequestBody to be used or null 
+     */
+    RequestBody filterRequestBody(RequestBody requestBody);
+    
+    /**
+     * Allows filtering of a particular APIResponse.  Implementers of this method can choose to update the given APIResponse,
+     * pass it back as-is, or return null if removing this APIResponse.
+     * 
+     * @return the APIResponse to be used or null 
+     */
+    APIResponse filterAPIResponse(APIResponse apiResponse);
+    
+    /**
+     * Allows filtering of a particular Schema.  Implementers of this method can choose to update the given Schema,
+     * pass it back as-is, or return null if removing this Schema.
+     * 
+     * @return the Schema to be used or null 
+     */
+    Schema<?> filterSchema(Schema<?> schema);
+    
+    /**
+     * Allows filtering of a particular SecurityScheme.  Implementers of this method can choose to update the given SecurityScheme,
+     * pass it back as-is, or return null if removing this SecurityScheme.
+     * 
+     * @return the SecurityScheme to be used or null 
+     */
+    SecurityScheme filterSecurityScheme(SecurityScheme securityScheme);
+    
+    /**
+     * Allows filtering of a particular Server.  Implementers of this method can choose to update the given Server,
+     * pass it back as-is, or return null if removing this Server.
+     * 
+     * @return the Server to be used or null 
+     */
+    Server filterServer(Server server);
+    
+    /**
+     * Allows filtering of a particular Tag.  Implementers of this method can choose to update the given Tag,
+     * pass it back as-is, or return null if removing this Tag.
+     * 
+     * @return the Tag to be used or null 
+     */
+    Tag filterTag(Tag tag);
+    
+    /**
+     * Allows filtering of a particular Link.  Implementers of this method can choose to update the given Link,
+     * pass it back as-is, or return null if removing this Link.
+     * 
+     * @return the Link to be used or null 
+     */
+    Link filterLink(Link link);
+    
+    /**
+     * Allows filtering of a particular Callback.  Implementers of this method can choose to update the given Callback,
+     * pass it back as-is, or return null if removing this Callback.
+     * 
+     * @return the Callback to be used or null 
+     */
+    Callback filterCallback(Callback callback);
+    
+    /**
+     * Allows filtering of the singleton OpenAPI element.  Implementers of this method can choose to update this element, or
+     * do nothing if no change is required.  Note that one cannot remove this element from the model tree, hence the return type
+     * of void.  
+     * 
+     * @return the OpenAPI object to be used
+     */
+    void filterOpenAPI(OpenAPI openAPI);
+}

--- a/api/src/main/java/org/eclipse/microprofile/openapi/OASFilter.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/OASFilter.java
@@ -41,11 +41,12 @@ import org.eclipse.microprofile.openapi.models.tags.Tag;
  *
  */
 public interface OASFilter {    
-	
-    /**
+
+    /** 
      * Allows filtering of a particular PathItem.  Implementers of this method can choose to update the given PathItem,
      * pass it back as-is, or return null if removing this PathItem.
      * 
+     * @param pathItem the current PathItem element
      * @return the PathItem to be used or null 
      */
     PathItem filterPathItem(PathItem pathItem);
@@ -54,6 +55,7 @@ public interface OASFilter {
      * Allows filtering of a particular Operation.  Implementers of this method can choose to update the given Operation,
      * pass it back as-is, or return null if removing this Operation.
      * 
+     * @param operation the current Operation element
      * @return the Operation to be used or null 
      */
     Operation filterOperation(Operation operation);
@@ -62,6 +64,7 @@ public interface OASFilter {
      * Allows filtering of a particular Parameter.  Implementers of this method can choose to update the given Parameter,
      * pass it back as-is, or return null if removing this Parameter.
      * 
+     * @param parameter the current Parameter element
      * @return the Parameter to be used or null 
      */
     Parameter filterParameter(Parameter parameter);
@@ -70,6 +73,7 @@ public interface OASFilter {
      * Allows filtering of a particular Header.  Implementers of this method can choose to update the given Header,
      * pass it back as-is, or return null if removing this Header.
      * 
+     * @param header the current Header element
      * @return the Header to be used or null 
      */
     Header filterHeader(Header header);
@@ -78,6 +82,7 @@ public interface OASFilter {
      * Allows filtering of a particular RequestBody.  Implementers of this method can choose to update the given RequestBody,
      * pass it back as-is, or return null if removing this RequestBody.
      * 
+     * @param requestBody the current RequestBody element
      * @return the RequestBody to be used or null 
      */
     RequestBody filterRequestBody(RequestBody requestBody);
@@ -86,6 +91,7 @@ public interface OASFilter {
      * Allows filtering of a particular APIResponse.  Implementers of this method can choose to update the given APIResponse,
      * pass it back as-is, or return null if removing this APIResponse.
      * 
+     * @param apiResponse the current APIResponse element
      * @return the APIResponse to be used or null 
      */
     APIResponse filterAPIResponse(APIResponse apiResponse);
@@ -94,6 +100,7 @@ public interface OASFilter {
      * Allows filtering of a particular Schema.  Implementers of this method can choose to update the given Schema,
      * pass it back as-is, or return null if removing this Schema.
      * 
+     * @param schema the current Schema element
      * @return the Schema to be used or null 
      */
     Schema<?> filterSchema(Schema<?> schema);
@@ -102,6 +109,7 @@ public interface OASFilter {
      * Allows filtering of a particular SecurityScheme.  Implementers of this method can choose to update the given SecurityScheme,
      * pass it back as-is, or return null if removing this SecurityScheme.
      * 
+     * @param securityScheme the current SecurityScheme element
      * @return the SecurityScheme to be used or null 
      */
     SecurityScheme filterSecurityScheme(SecurityScheme securityScheme);
@@ -110,6 +118,7 @@ public interface OASFilter {
      * Allows filtering of a particular Server.  Implementers of this method can choose to update the given Server,
      * pass it back as-is, or return null if removing this Server.
      * 
+     * @param server the current Server element
      * @return the Server to be used or null 
      */
     Server filterServer(Server server);
@@ -118,6 +127,7 @@ public interface OASFilter {
      * Allows filtering of a particular Tag.  Implementers of this method can choose to update the given Tag,
      * pass it back as-is, or return null if removing this Tag.
      * 
+     * @param tag the current Tag element
      * @return the Tag to be used or null 
      */
     Tag filterTag(Tag tag);
@@ -126,6 +136,7 @@ public interface OASFilter {
      * Allows filtering of a particular Link.  Implementers of this method can choose to update the given Link,
      * pass it back as-is, or return null if removing this Link.
      * 
+     * @param link the current Link element
      * @return the Link to be used or null 
      */
     Link filterLink(Link link);
@@ -134,6 +145,7 @@ public interface OASFilter {
      * Allows filtering of a particular Callback.  Implementers of this method can choose to update the given Callback,
      * pass it back as-is, or return null if removing this Callback.
      * 
+     * @param callback the current Callback element
      * @return the Callback to be used or null 
      */
     Callback filterCallback(Callback callback);
@@ -143,7 +155,7 @@ public interface OASFilter {
      * do nothing if no change is required.  Note that one cannot remove this element from the model tree, hence the return type
      * of void.  
      * 
-     * @return the OpenAPI object to be used
+     * @param openAPI the current OpenAPI element
      */
     void filterOpenAPI(OpenAPI openAPI);
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/OASFilter.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/OASFilter.java
@@ -153,7 +153,8 @@ public interface OASFilter {
     /**
      * Allows filtering of the singleton OpenAPI element.  Implementers of this method can choose to update this element, or
      * do nothing if no change is required.  Note that one cannot remove this element from the model tree, hence the return type
-     * of void.  
+     * of void. This is the last method called for a given filter, therefore it symbolizes the end of processing by the vendor
+     * framework.
      * 
      * @param openAPI the current OpenAPI element
      */

--- a/api/src/main/java/org/eclipse/microprofile/openapi/OASModelReader.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/OASModelReader.java
@@ -23,14 +23,18 @@ import org.eclipse.microprofile.openapi.models.OpenAPI;
  * In this scenario the developer can choose whether to provide the entire OpenAPI model while disabling annotation
  * scanning, or they can provide a starting OpenAPI model to be augmented with the application annotations.  
  *
+ * The registration of this model reader is controlled by setting the key <b>mp.openapi.model.reader</b> using
+ * one of the configuration sources specified in <a href="https://github.com/eclipse/microprofile-config">MicroProfile Config</a>.
+ * The value is the fully qualified name of the model reader implementation, which needs to be visible to the application's classloader.
+
  */
-public interface OASReader {
+public interface OASModelReader {
 
     /**
      * This method is called by the vendor's OpenAPI processing framework.  It can be a fully complete and valid OpenAPI
-     * model tree, or a partial base model tree that will be augment by either annotations or pre-generated OpenAPI documents.
+     * model tree, or a partial base model tree that will be augmented by either annotations or pre-generated OpenAPI documents.
      * 
      * @return the OpenAPI model to be used by the vendor
      */
-    OpenAPI read();
+    OpenAPI buildModel();
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/OASReader.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/OASReader.java
@@ -32,5 +32,5 @@ public interface OASReader {
      * 
      * @return the OpenAPI model to be used by the vendor
      */
-	OpenAPI read();
+    OpenAPI read();
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/OASReader.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/OASReader.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.openapi;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+
+/**
+ * This interface allows application developers to programmatically contribute an OpenAPI model tree.  
+ * 
+ * In this scenario the developer can choose whether to provide the entire OpenAPI model while disabling annotation
+ * scanning, or they can provide a starting OpenAPI model to be augmented with the application annotations.  
+ *
+ */
+public interface OASReader {
+
+    /**
+     * This method is called by the vendor's OpenAPI processing framework.  It can be a fully complete and valid OpenAPI
+     * model tree, or a partial base model tree that will be augment by either annotations or pre-generated OpenAPI documents.
+     * 
+     * @return the OpenAPI model to be used by the vendor
+     */
+	OpenAPI read();
+}

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/Operation.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/Operation.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
-import org.eclipse.microprofile.openapi.annotations.responses.ApiResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.servers.Server;
 
@@ -98,7 +98,7 @@ public @interface Operation {
      *
      * @return the list of responses for this operation
      **/
-    ApiResponse[] responses() default {};
+    APIResponse[] responses() default {};
 
     /**
      * Allows an operation to be marked as deprecated. Alternatively use the @Deprecated annotation

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponse.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponse.java
@@ -50,8 +50,8 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 @Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@Repeatable(ApiResponses.class)
-public @interface ApiResponse {
+@Repeatable(APIResponses.class)
+public @interface APIResponse {
     /**
      * A short description of the response. This is a REQUIRED property.
      * 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponses.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponses.java
@@ -26,16 +26,16 @@ import java.lang.annotation.Target;
  * The ApiResponses annotation is a container for @ApiResponse annotations. When used on a method
  * it is treated as if each ApiResponse annotation were applied individually.
  * 
- * @see ApiResponse
+ * @see APIResponse
  **/
 @Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface APIResponses {
     /**
-     * An array of ApiResponse annotations
+     * An array of APIResponse annotations
      *
-     * @return the array of the ApiResponse
+     * @return the array of the APIResponse
      **/
     APIResponse[] value() default {};
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponses.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponses.java
@@ -31,12 +31,12 @@ import java.lang.annotation.Target;
 @Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-public @interface ApiResponses {
+public @interface APIResponses {
     /**
      * An array of ApiResponse annotations
      *
      * @return the array of the ApiResponse
      **/
-    ApiResponse[] value() default {};
+    APIResponse[] value() default {};
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/Components.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/Components.java
@@ -26,7 +26,7 @@ import org.eclipse.microprofile.openapi.models.links.Link;
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
-import org.eclipse.microprofile.openapi.models.responses.ApiResponse;
+import org.eclipse.microprofile.openapi.models.responses.APIResponse;
 import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
 
 /**
@@ -87,14 +87,14 @@ public interface Components extends Constructible, Extensible {
      *
      * @return a Map containing the keys and the reusable responses from API operations for this OpenAPI document
      **/
-    Map<String, ApiResponse> getResponses();
+    Map<String, APIResponse> getResponses();
 
     /**
      * Sets this Components' responses property to the given Map containing keys and reusable response objects.
      *
      * @param responses a Map containing keys and reusable response objects
      */
-    void setResponses(Map<String, ApiResponse> responses);
+    void setResponses(Map<String, APIResponse> responses);
 
     /**
      * Sets this Components' responses property to the given Map containing keys and reusable response objects.
@@ -102,7 +102,7 @@ public interface Components extends Constructible, Extensible {
      * @param responses a Map containing keys and reusable response objects
      * @return the current Components object
      */
-    Components responses(Map<String, ApiResponse> responses);
+    Components responses(Map<String, APIResponse> responses);
 
     /**
      * Adds the given response to this Components' map of responses with the given string as its key.
@@ -111,7 +111,7 @@ public interface Components extends Constructible, Extensible {
      * @param responsesItem a reusable response object
      * @return the current Components object
      */
-    Components addResponses(String key, ApiResponse responsesItem);
+    Components addResponses(String key, APIResponse responsesItem);
 
     /**
      * Returns the parameters property from a Components instance.

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/Operation.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/Operation.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.eclipse.microprofile.openapi.models.callbacks.Callback;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
-import org.eclipse.microprofile.openapi.models.responses.ApiResponses;
+import org.eclipse.microprofile.openapi.models.responses.APIResponses;
 import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.models.servers.Server;
 
@@ -213,14 +213,14 @@ public interface Operation extends Constructible, Extensible {
      *
      * @return collection of possible responses from executing this operation
      **/
-    ApiResponses getResponses();
+    APIResponses getResponses();
 
     /**
      * Sets this Operation's responses property to the given responses.
      *
      * @param responses collection of possible responses from executing this operation
      **/
-    void setResponses(ApiResponses responses);
+    void setResponses(APIResponses responses);
 
     /**
      * Sets this Operation's responses property to the given responses.
@@ -228,7 +228,7 @@ public interface Operation extends Constructible, Extensible {
      * @param responses collection of possible responses from executing this operation
      * @return the current Operation object
      **/
-    Operation responses(ApiResponses responses);
+    Operation responses(APIResponses responses);
 
     /**
      * Returns the callbacks property from an Operation instance.

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponse.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponse.java
@@ -31,7 +31,7 @@ import org.eclipse.microprofile.openapi.models.media.Content;
  *
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.0-rc2/versions/3.0.md#responseObject"
  */
-public interface ApiResponse extends Constructible, Extensible, Reference<ApiResponse> {
+public interface APIResponse extends Constructible, Extensible, Reference<APIResponse> {
 
     /**
      * Returns a short description of this instance of ApiResponse.
@@ -56,7 +56,7 @@ public interface ApiResponse extends Constructible, Extensible, Reference<ApiRes
      * @return this ApiResponse instance
      */
 
-    ApiResponse description(String description);
+    APIResponse description(String description);
 
     /**
      * Returns the map of Headers in this instance of ApiResponse.
@@ -83,7 +83,7 @@ public interface ApiResponse extends Constructible, Extensible, Reference<ApiRes
      * @return this ApiResponse instance
      */
 
-    ApiResponse headers(Map<String, Header> headers);
+    APIResponse headers(Map<String, Header> headers);
 
     /**
      * Adds the given Header to this ApiResponse instance's map of Headers with the given name and return this instance of ApiResponse. If this
@@ -94,7 +94,7 @@ public interface ApiResponse extends Constructible, Extensible, Reference<ApiRes
      * @return this ApiResponse instance
      */
 
-    ApiResponse addHeaderObject(String name, Header header);
+    APIResponse addHeaderObject(String name, Header header);
 
     /**
      * Returns the map containing descriptions of potential response payload for this instance of ApiResponse.
@@ -119,7 +119,7 @@ public interface ApiResponse extends Constructible, Extensible, Reference<ApiRes
      * @return this ApiResponse instance
      */
 
-    ApiResponse content(Content content);
+    APIResponse content(Content content);
 
     /**
      * Returns the operations links that can be followed from tis instance of ApiResponse.
@@ -145,6 +145,6 @@ public interface ApiResponse extends Constructible, Extensible, Reference<ApiRes
      * @return this ApiResponse instance
      */
 
-    ApiResponse link(String name, Link link);
+    APIResponse link(String name, Link link);
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponses.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponses.java
@@ -27,7 +27,7 @@ import org.eclipse.microprofile.openapi.models.Constructible;
  *
  * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.0-rc2/versions/3.0.md#responsesObject">Responses Object</a>
  */
-public interface ApiResponses extends Constructible, Map<String, ApiResponse> {
+public interface APIResponses extends Constructible, Map<String, APIResponse> {
 
     public static final String DEFAULT = "default";
 
@@ -38,7 +38,7 @@ public interface ApiResponses extends Constructible, Map<String, ApiResponse> {
      * @param item the ApiResponse object to be added to ApiResponses map
      * @return ApiResponses map with the added ApiResponse instance
      **/
-    ApiResponses addApiResponse(String name, ApiResponse item);
+    APIResponses addApiResponse(String name, APIResponse item);
 
     /**
      * Returns the default documentation of responses other than the ones declared for specific HTTP response codes in this instance of ApiResponses.
@@ -46,7 +46,7 @@ public interface ApiResponses extends Constructible, Map<String, ApiResponse> {
      * @return the default documentation of responses
      **/
 
-    ApiResponse getDefault();
+    APIResponse getDefault();
 
     /**
      * Sets the default documentation of responses for this instance of ApiResponses. This will cover all the undeclared responses.
@@ -54,7 +54,7 @@ public interface ApiResponses extends Constructible, Map<String, ApiResponse> {
      * @param defaultValue the default documentation of responses
      */
 
-    void setDefaultValue(ApiResponse defaultValue);
+    void setDefaultValue(APIResponse defaultValue);
 
     /**
      * Sets the default documentation of responses for this instance of ApiResponses and return this instance of ApiResponses. This will cover all the
@@ -64,6 +64,6 @@ public interface ApiResponses extends Constructible, Map<String, ApiResponse> {
      * @return this ApiResponses instance
      */
 
-    ApiResponses defaultValue(ApiResponse defaultValue);
+    APIResponses defaultValue(APIResponse defaultValue);
 
 }


### PR DESCRIPTION
-  The OASModelReader is the way that users contribute a model tree:  either a complete tree + disabled annotation, or stub tree + (annotation | pre-generated file)    

- The OASFilter is a general filter, which can filter model elements anytime the vendor creates new models, which is during two cases:  (1) processing annotations, or  (2) parsing a document (either complete or stub).   The last method "void filterOpenAPI" is the last called method of the filter, and returns void because we don't want to give users the ability to not return at least an OpenAPI (but they remove any of the other elements by returning null to any of the filter methods).

- Changed `ApiResponse` to `APIResponse` and `ApiResponses` to `APIResponses`.  It was weird to have `Api`, since we always refer to it with capital letters.

An app developer would register their filter / reader with the following keys:

```
mp.openapi.filter=myPackage.myFilter
mp.openapi.model.reader=myPackage.myReader
```