### PR TITLE
Allowing factory to bet set via SPI

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/OASFactory.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/OASFactory.java
@@ -31,8 +31,6 @@ public final class OASFactory {
     
     private OASFactory() {}
 
-    private static final OASFactoryResolver INSTANCE = OASFactoryResolver.instance();
-
     /**
      * This method creates a new instance of a constructible element from the OpenAPI model tree.
      *
@@ -48,7 +46,7 @@ public final class OASFactory {
      * @throws IllegalArgumentException if an instance could not be created, most likely, due to an illegal or inappropriate class
      */
     public static <T extends Constructible> T createObject(Class<T> clazz) {
-        return INSTANCE.createObject(clazz);
+        return OASFactoryResolver.instance().createObject(clazz);
     }
 
 }


### PR DESCRIPTION
Allow the OASFactory to change after the class was loaded - in case there were timing issues in an OSGi or equivalent framework.

Signed-off-by: Arthur De Magalhaes <ademagalhaes@gmail.com>