### PR TITLE
Annotation changes - added name attribute where needed + javadoc to clarify when attributes are required

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/OpenAPIDefinition.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/OpenAPIDefinition.java
@@ -33,7 +33,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @Inherited
 public @interface OpenAPIDefinition {
     /**
-     * Provides metadata about the API. The metadata MAY be used by tooling as required.
+     * Required: Provides metadata about the API. The metadata MAY be used by tooling as required.
      *
      * @return the metadata about this API
      */

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/callbacks/Callback.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/callbacks/Callback.java
@@ -35,18 +35,25 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 @Inherited
 public @interface Callback {
     /**
-     * The friendly name used to refer to this callback
+     * The friendly name used to refer to this callback. This is a REQUIRED property unless this is only a reference to a callback.
+     * <p>
+     * The name is REQUIRED when the callback is defined within {@link org.eclipse.microprofile.openapi.annotations.Components}. The 
+     * name will be used as the key to add this callback to the 'callbacks' map for reuse.
+     * </p>
      * 
-     * @return the name of the callback
+     * @return the name of this callback
      **/
-    String name();
+    String name() default "";
 
     /**
      * An absolute URL which defines the destination which will be called with the supplied operation definition.
+     * <p>
+     * This is a REQUIRED property unless this is only a reference to a callback instance.
+     * </p>
      * 
      * @return the callback URL
      */
-    String callbackUrlExpression();
+    String callbackUrlExpression() default "";
 
     /**
      * The array of operations that will be called out-of band

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/callbacks/Callback.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/callbacks/Callback.java
@@ -35,7 +35,7 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 @Inherited
 public @interface Callback {
     /**
-     * The friendly name used to refer to this callback. This is a REQUIRED property unless this is only a reference to a callback.
+     * The friendly name used to refer to this callback. It is a REQUIRED property unless this is only a reference to a callback.
      * <p>
      * The name is REQUIRED when the callback is defined within {@link org.eclipse.microprofile.openapi.annotations.Components}. The 
      * name will be used as the key to add this callback to the 'callbacks' map for reuse.
@@ -48,7 +48,7 @@ public @interface Callback {
     /**
      * An absolute URL which defines the destination which will be called with the supplied operation definition.
      * <p>
-     * This is a REQUIRED property unless this is only a reference to a callback instance.
+     * It is a REQUIRED property unless this is only a reference to a callback instance.
      * </p>
      * 
      * @return the callback URL

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/enums/SecuritySchemeIn.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/enums/SecuritySchemeIn.java
@@ -18,7 +18,7 @@
 package org.eclipse.microprofile.openapi.annotations.enums;
 
 public enum SecuritySchemeIn {
-    HEADER("header"), QUERY("query"), COOKIE("cookie");
+    DEFAULT(""), HEADER("header"), QUERY("query"), COOKIE("cookie");
 
     private String value;
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/enums/SecuritySchemeType.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/enums/SecuritySchemeType.java
@@ -18,7 +18,7 @@
 package org.eclipse.microprofile.openapi.annotations.enums;
 
 public enum SecuritySchemeType {
-    APIKEY("apiKey"), HTTP("http"), OPENIDCONNECT("openIdConnect"), OAUTH2("oauth2");
+    DEFAULT(""), APIKEY("apiKey"), HTTP("http"), OPENIDCONNECT("openIdConnect"), OAUTH2("oauth2");
 
     private String value;
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/headers/Header.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/headers/Header.java
@@ -34,7 +34,7 @@ public @interface Header {
     /**
      * The name of the header. The name is only used as the key to add this header to a map.
      * <p>
-     * This is a REQUIRED property unless this is only a reference to a header instance.
+     * It is a REQUIRED property unless this is only a reference to a header instance.
      * </p>
      * When the header is defined within {@link org.eclipse.microprofile.openapi.annotations.Components}, 
      * the name will be used as the key to add this header to the 'headers' map for reuse.

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/headers/Header.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/headers/Header.java
@@ -32,11 +32,16 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @Inherited
 public @interface Header {
     /**
-     * Required: The name of the header. The name is only used as the key to store this header in a map.
+     * The name of the header. The name is only used as the key to add this header to a map.
+     * <p>
+     * This is a REQUIRED property unless this is only a reference to a header instance.
+     * </p>
+     * When the header is defined within {@link org.eclipse.microprofile.openapi.annotations.Components}, 
+     * the name will be used as the key to add this header to the 'headers' map for reuse.
      * 
      * @return this header's name
      **/
-    String name();
+    String name() default "";
 
     /**
      * Additional description data to provide on the purpose of the header

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/links/Link.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/links/Link.java
@@ -34,6 +34,10 @@ import org.eclipse.microprofile.openapi.annotations.servers.Server;
 public @interface Link {
     /**
      * The name of this link.
+     * <p>
+     * The name is REQUIRED when the link is defined within {@link org.eclipse.microprofile.openapi.annotations.Components}. The
+     * name will be used as the key to add this link to the 'links' map for reuse.
+     * </p>
      * 
      * @return the link's name
      **/

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/media/ExampleObject.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/media/ExampleObject.java
@@ -31,6 +31,10 @@ import java.lang.annotation.Target;
 public @interface ExampleObject {
     /**
      * A unique name to identify this particular example in a map.
+     * <p>
+     * The name is REQUIRED when the example is defined within {@link org.eclipse.microprofile.openapi.annotations.Components}. The 
+     * name will be used as the key to add this example to the 'examples' map for reuse.
+     * </p>
      * 
      * @return the name of this example
      **/

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/media/Schema.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/media/Schema.java
@@ -83,6 +83,10 @@ public @interface Schema {
 
     /**
      * The name of the schema or property.
+     * <p>
+     * The name is REQUIRED when the schema is defined within {@link org.eclipse.microprofile.openapi.annotations.Components}. The 
+     * name will be used as the key to add this schema to the 'schemas' map for reuse.
+     * </p>
      * 
      * @return the name of the schema
      **/

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/Parameter.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/Parameter.java
@@ -40,8 +40,11 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @Inherited
 public @interface Parameter {
     /**
-     * This is a REQUIRED property of a parameter instance.
      * The name of the parameter. Parameter names are case sensitive.
+     * This is a REQUIRED property unless this is only a reference to a parameter instance.
+     * <p>
+     * When the parameter is defined within {@link org.eclipse.microprofile.openapi.annotations.Components}, 
+     * the name will be used as the key to add this parameter to the 'parameters' map for reuse.
      * <p>
      * If in is "path", the name field MUST correspond to the associated path segment from the path field in the Paths Object. 
      * See Path Templating for further information.
@@ -55,9 +58,8 @@ public @interface Parameter {
     String name() default "";
 
     /**
-     * This is a REQUIRED property of a parameter instance.
+     * The location of the parameter. This is a REQUIRED property unless this is only a reference to a parameter instance.
      * <p>
-     * The location of the parameter. 
      * Possible values are specified in ParameterIn enum. Ignored when empty string.
      * </p>
      * @return this parameter's location

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/Parameter.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/Parameter.java
@@ -41,7 +41,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 public @interface Parameter {
     /**
      * The name of the parameter. Parameter names are case sensitive.
-     * This is a REQUIRED property unless this is only a reference to a parameter instance.
+     * It is a REQUIRED property unless this is only a reference to a parameter instance.
      * <p>
      * When the parameter is defined within {@link org.eclipse.microprofile.openapi.annotations.Components}, 
      * the name will be used as the key to add this parameter to the 'parameters' map for reuse.
@@ -58,7 +58,7 @@ public @interface Parameter {
     String name() default "";
 
     /**
-     * The location of the parameter. This is a REQUIRED property unless this is only a reference to a parameter instance.
+     * The location of the parameter. It is a REQUIRED property unless this is only a reference to a parameter instance.
      * <p>
      * Possible values are specified in ParameterIn enum. Ignored when empty string.
      * </p>

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/RequestBody.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/RequestBody.java
@@ -43,7 +43,7 @@ public @interface RequestBody {
     String description() default "";
 
     /**
-     * The content of the request body. This is a REQUIRED property unless this is only a reference to a request body instance.
+     * The content of the request body. It is a REQUIRED property unless this is only a reference to a request body instance.
      * 
      * @return content of this requestBody instance
      **/

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/RequestBody.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/RequestBody.java
@@ -43,7 +43,7 @@ public @interface RequestBody {
     String description() default "";
 
     /**
-     * This is a REQUIRED property. The content of the request body.
+     * The content of the request body. This is a REQUIRED property unless this is only a reference to a request body instance.
      * 
      * @return content of this requestBody instance
      **/
@@ -56,6 +56,15 @@ public @interface RequestBody {
      **/
     boolean required() default false;
 
+    /**
+     * The unique name to identify this request body. Only REQUIRED when the request body is defined
+     * within {@link org.eclipse.microprofile.openapi.annotations.Components}. The name will be 
+     * used as the key to add this request body to the 'requestBodies' map for reuse.
+     * 
+     * @return this request body's name
+     **/
+    String name() default "";
+    
     /**
      * Reference value to a RequestBody object.
      *

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponse.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponse.java
@@ -53,7 +53,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 @Repeatable(APIResponses.class)
 public @interface APIResponse {
     /**
-     * A short description of the response. This is a REQUIRED property unless this is only a reference to a response instance.
+     * A short description of the response. It is a REQUIRED property unless this is only a reference to a response instance.
      * 
      * @return description of the response.
      **/

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponse.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponse.java
@@ -53,7 +53,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 @Repeatable(APIResponses.class)
 public @interface APIResponse {
     /**
-     * A short description of the response. This is a REQUIRED property.
+     * A short description of the response. This is a REQUIRED property unless this is only a reference to a response instance.
      * 
      * @return description of the response.
      **/
@@ -62,7 +62,7 @@ public @interface APIResponse {
     /**
      * The HTTP response code, or 'default', for the supplied response. May only have 1 default entry.
      * 
-     * @return HHTTP response code for this response instance or default
+     * @return HTTP response code for this response instance or default
      **/
     String responseCode() default "default";
 
@@ -88,6 +88,15 @@ public @interface APIResponse {
      * @return content of this response instance
      **/
     Content[] content() default {};
+
+    /**
+     * The unique name to identify this response. Only REQUIRED when the response is defined
+     * within {@link org.eclipse.microprofile.openapi.annotations.Components}. The name will
+     * be used as the key to add this response to the 'responses' map for reuse.
+     * 
+     * @return this response's name
+     **/
+    String name() default "";
 
     /**
      * Reference value to a Response object.

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityScheme.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityScheme.java
@@ -37,20 +37,21 @@ import java.lang.annotation.Target;
 @Inherited
 public @interface SecurityScheme {
     /**
-     * The name of this SecurityScheme.
-     * Used as a key in the key-value pair of a SecuritySchemes map 
-     * 
+     * The name of this SecurityScheme. Used as the key to add this security scheme to the 'securitySchemes' map under Components object.
+     * <p>
+     * This is a REQUIRED property unless this is only a reference to a security scheme instance.
+     * </p>
      * @return the name of this SecurityScheme instance
      **/
     String securitySchemeName() default "";
     /**
-     * Type is a REQUIRED property that specifies the type of SecurityScheme instance.
+     * The type of the security scheme. Valid values are defined by SecuritySchemeType enum. Ignored when empty string.
      * <p>
-     * The type of the security scheme. Valid values are defined by SecuritySchemeType enum.
+     * Type is a REQUIRED property unless this is only a reference to a SecuirtyScheme instance.
      * </p>
      * @return the type of this SecuirtyScheme instance
      **/
-    SecuritySchemeType type();
+    SecuritySchemeType type() default SecuritySchemeType.DEFAULT;
 
     /**
      * A short description for security scheme. 
@@ -73,11 +74,11 @@ public @interface SecurityScheme {
      * Applies to and is REQUIRED for SecurityScheme of apiKey type.
      * <p>
      * The location of the API key. 
-     * Valid values are defined by SecuritySchemeIn enum.
+     * Valid values are defined by SecuritySchemeIn enum. Ignored when empty string.
      * </p>
      * @return the location of the API key
      **/
-    SecuritySchemeIn in() default SecuritySchemeIn.QUERY;
+    SecuritySchemeIn in() default SecuritySchemeIn.DEFAULT;
 
     /**
      * Applies to and is REQUIRED for SecurityScheme of http type.

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityScheme.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityScheme.java
@@ -39,7 +39,7 @@ public @interface SecurityScheme {
     /**
      * The name of this SecurityScheme. Used as the key to add this security scheme to the 'securitySchemes' map under Components object.
      * <p>
-     * This is a REQUIRED property unless this is only a reference to a security scheme instance.
+     * It is a REQUIRED property unless this is only a reference to a security scheme instance.
      * </p>
      * @return the name of this SecurityScheme instance
      **/

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/tags/Tag.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/tags/Tag.java
@@ -81,11 +81,11 @@ import org.eclipse.microprofile.openapi.annotations.ExternalDocumentation;
 public @interface Tag {
 
     /**
-     * The name of this tag.
+     * The name of this tag. This is a REQUIRED property unless this is only a reference to a tag instance.
      *
      * @return the name of this tag
      */
-    String name();
+    String name() default "";
 
     /**
      * A short description for this tag.

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/tags/Tag.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/tags/Tag.java
@@ -81,7 +81,7 @@ import org.eclipse.microprofile.openapi.annotations.ExternalDocumentation;
 public @interface Tag {
 
     /**
-     * The name of this tag. This is a REQUIRED property unless this is only a reference to a tag instance.
+     * The name of this tag. It is a REQUIRED property unless this is only a reference to a tag instance.
      *
      * @return the name of this tag
      */


### PR DESCRIPTION
- Added name attribute to APIResponse and RequestBody so they can be stored under components
- Added javadoc to clarify when the name attribute is required and how it's used
- Added default values for all attributes of referenceable items, so user can easily define a reference by only specifying the 'ref' attribute
-  Clarified that for references other attributes are not required
- Added empty value to enums SecuritySchemeIn and SecuritySchemeType  and set it as default value (similar to ParameterIn and ParameterStyle).