### PR TITLE
Updating annotations

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/Operation.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/Operation.java
@@ -23,13 +23,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
-import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
-import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
-import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
-import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
-import org.eclipse.microprofile.openapi.annotations.servers.Server;
-
 /**
  * Describes a single API operation on a path.
  * 
@@ -40,21 +33,6 @@ import org.eclipse.microprofile.openapi.annotations.servers.Server;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface Operation {
-    /**
-     * The HTTP method for this operation.
-     *
-     * @return the HTTP method of this operation
-     **/
-    String method() default "";
-
-    /**
-     * A list of tags for API documentation control.
-     * <p>
-     * Tags can be used for logical grouping of operations by resources or any other qualifier.
-     * </p>
-     * @return the list of tags associated with this operation
-     **/
-    String[] tags() default {};
 
     /**
      * Provides a brief description of what this operation does.
@@ -72,13 +50,6 @@ public @interface Operation {
     String description() default "";
 
     /**
-     * Additional external documentation for this operation.
-     *
-     * @return external documentation associated with this operation instance
-     **/
-    ExternalDocumentation externalDocs() default @ExternalDocumentation();
-
-    /**
      * Unique string used to identify the operation. 
      * The id MUST be unique among all operations described in the API.
      * <p>
@@ -90,33 +61,6 @@ public @interface Operation {
     String operationId() default "";
 
     /**
-     * An array of parameters applicable for this operation, 
-     * which will be added to any automatically detected parameters in the method itself.
-     * <p>
-     * The list MUST NOT include duplicated parameters. 
-     * A unique parameter is defined by a combination of a name and location.
-     * </p>
-     * @return the list of parameters for this operation
-     **/
-    Parameter[] parameters() default {};
-
-    /**
-     * The request body applicable for this operation.
-     *
-     * @return the request body of this operation
-     **/
-    RequestBody requestBody() default @RequestBody();
-
-    /**
-     * This is a REQUIRED property of an operation instance.
-     * <p>
-     * The list of possible responses as they are returned from executing this operation.
-     * </p>
-     * @return the list of responses for this operation
-     **/
-    APIResponse[] responses() default {};
-
-    /**
      * Allows an operation to be marked as deprecated. 
      * Alternatively use the @Deprecated annotation.
      * <p>
@@ -125,34 +69,6 @@ public @interface Operation {
      * @return whether or not this operation is deprecated
      **/
     boolean deprecated() default false;
-
-    /**
-     * A declaration of which security mechanisms can be used for this operation.
-     * Only one of the security requirement objects need to be satisfied to authorize a request. 
-     * <p>
-     * This definition overrides any declared top-level security. 
-     * To remove a top-level security declaration, an empty array can be used.
-     * </p>
-     * @return the list of security mechanisms for this operation
-     */
-    SecurityRequirement[] security() default {};
-
-    /**
-     * An alternative server array to service this operation.
-     * <p>
-     * If an alternative server object is specified at the Path Item Object or Root level, 
-     * it will be overridden by this value.
-     * </p>
-     * @return the list of servers hosting this operation
-     **/
-    Server[] servers() default {};
-
-    /**
-     * The list of optional extensions.
-     *
-     * @return an optional array of extensions
-     */
-    Extension[] extensions() default {};
 
     /**
      * Allows this operation to be marked as hidden

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/callbacks/Callback.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/callbacks/Callback.java
@@ -24,8 +24,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.eclipse.microprofile.openapi.annotations.Operation;
-
 /**
  * This object represents a callback URL that will be invoked.
  * 
@@ -62,7 +60,7 @@ public @interface Callback {
      * 
      * @return the callback operations
      **/
-    Operation[] operation() default {};
+    CallbackOperation[] operations() default {};
 
     /**
      * Reference value to a Callback object.

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/callbacks/CallbackOperation.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/callbacks/CallbackOperation.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright 2017 SmartBear Software
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.openapi.annotations.callbacks;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.eclipse.microprofile.openapi.annotations.ExternalDocumentation;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+
+/**
+ * Describes a single API callback operation.
+ * 
+ * @see <a href= "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#operationObject">OpenAPI Specification Operation
+ *      Object</a>
+ **/
+@Target({ })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface CallbackOperation {
+    /**
+     * The HTTP method for this callback operation.
+     *
+     * @return the HTTP method of this callback operation
+     **/
+    String method() default "";
+
+    /**
+     * Provides a brief description of what this callback operation does.
+     *
+     * @return a summary of this callback operation
+     **/
+    String summary() default "";
+
+    /**
+     * A verbose description of the callback operation behavior.
+     * CommonMark syntax MAY be used for rich text representation.
+     *
+     * @return a description of this callback operation
+     **/
+    String description() default "";
+
+    /**
+     * Additional external documentation for this callback operation.
+     *
+     * @return external documentation associated with this callback operation instance
+     **/
+    ExternalDocumentation externalDocs() default @ExternalDocumentation();
+
+    /**
+     * An array of parameters applicable for this callback operation, 
+     * which will be added to any automatically detected parameters in the method itself.
+     * <p>
+     * The list MUST NOT include duplicated parameters. 
+     * A unique parameter is defined by a combination of a name and location.
+     * </p>
+     * @return the list of parameters for this callback operation
+     **/
+    Parameter[] parameters() default {};
+
+    /**
+     * The request body applicable for this callback operation.
+     *
+     * @return the request body of this callback operation
+     **/
+    RequestBody requestBody() default @RequestBody();
+
+    /**
+     * This is a REQUIRED property of an callback operation instance.
+     * <p>
+     * The list of possible responses as they are returned from executing this callback operation.
+     * </p>
+     * @return the list of responses for this callback operation
+     **/
+    APIResponse[] responses() default {};
+
+    /**
+     * A declaration of which security mechanisms can be used for this callback operation.
+     * Only one of the security requirement objects need to be satisfied to authorize a request. 
+     * <p>
+     * This definition overrides any declared top-level security. 
+     * To remove a top-level security declaration, an empty array can be used.
+     * @return the list of security mechanisms for this callback operation
+     */
+    SecurityRequirement[] security() default {};
+
+    /**
+     * The list of optional extensions.
+     *
+     * @return an optional array of extensions
+     */
+    Extension[] extensions() default {};
+}

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/RequestBody.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/RequestBody.java
@@ -60,7 +60,9 @@ public @interface RequestBody {
 
     /**
      * The unique name to identify this request body. Unless this annotation is used on the actual request body parameter,
-     * it is required to match the name of that parameter so the appropriate association can be made.
+     * it is required to match the name of that parameter so the appropriate association can be made.  When the request body
+     * is defined within {@link org.eclipse.microprofile.openapi.annotations.Components}. The name will be used as the key to 
+     * add this request body to the 'requestBodies' map for reuse.
      * 
      * @return this request body's name
      **/

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/RequestBody.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/RequestBody.java
@@ -30,7 +30,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
  * 
  * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.0-rc2/versions/3.0.md#requestBodyObject">requestBody Object</a>
  **/
-@Target({ ElementType.PARAMETER })
+@Target({ ElementType.PARAMETER, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface RequestBody {
@@ -59,9 +59,8 @@ public @interface RequestBody {
     boolean required() default false;
 
     /**
-     * The unique name to identify this request body. Only REQUIRED when the request body is defined
-     * within {@link org.eclipse.microprofile.openapi.annotations.Components}. The name will be 
-     * used as the key to add this request body to the 'requestBodies' map for reuse.
+     * The unique name to identify this request body. Unless this annotation is used on the actual request body parameter,
+     * it is required to match the name of that parameter so the appropriate association can be made.
      * 
      * @return this request body's name
      **/


### PR DESCRIPTION
- reduced `@Operation` to only contain the necessary fields that aren't available at the method level
- created a new `@CallbackOperation` to represent an operation within a callback object
- Updated RequestBody to be specified in the method level

Signed-off-by: Arthur De Magalhaes <ademagalhaes@gmail.com>