### PR TITLE
Removed ref from SecurityScheme annotation

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityScheme.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityScheme.java
@@ -119,16 +119,4 @@ public @interface SecurityScheme {
      * @return URL where OAuth2 configuration values are stored
      **/
     String openIdConnectUrl() default "";
-
-    /**
-     * Reference value to a SecurityScheme object.
-     * <p>
-     * This property provides a reference to an object defined elsewhere. This property and
-     * all other properties are mutually exclusive. If other properties are defined in addition
-     * to the ref property then the result is undefined.
-     *
-     * @return reference to a security scheme
-     **/
-    String ref() default "";
-
 }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/UserResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/UserResource.java
@@ -29,6 +29,7 @@ import org.eclipse.microprofile.openapi.annotations.enums.ParameterStyle;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
+import org.eclipse.microprofile.openapi.annotations.security.SecuritySchemes;
 import org.eclipse.microprofile.openapi.annotations.servers.Server;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.tags.Tags;
@@ -55,13 +56,23 @@ import javax.ws.rs.core.Response;
 
 @Path("/user")
 @Produces({"application/json", "application/xml"})
-@SecurityScheme(
-    description = "user security scheme",
-    type = SecuritySchemeType.HTTP,
-    securitySchemeName = "httpTestScheme",
-    scheme = "testScheme")
+@SecuritySchemes(
+    value = {
+        @SecurityScheme(
+            description = "user security scheme",
+            type = SecuritySchemeType.HTTP,
+            securitySchemeName = "httpTestScheme",
+            scheme = "testScheme"),
+        @SecurityScheme(
+            description = "another user security scheme",
+            type = SecuritySchemeType.HTTP,
+            securitySchemeName = "httpTestSchemeWithScope",
+            scheme = "anotherTestScheme"
+        )
+    }
+)
 @SecurityRequirement(
-    name = "httpTestScheme",
+    name = "httpTestSchemeWithScope",
     scopes = "write:users"
 )
 public class UserResource {
@@ -516,9 +527,6 @@ public class UserResource {
         operationId = "logInUser"
     )
 
-    @SecurityScheme(
-        ref = "#/components/securitySchemes/httpTestScheme"
-    )
     @SecurityRequirement(
         name = "httpTestScheme"
     )


### PR DESCRIPTION
As per discussion with @arturdzm, removed ref from SecurityScheme annotation and from the app.
Added a SecurityScheme to airlines app to resolve a conflict with precedence. 