### PR TITLE
Revert "Removed ref from SecurityScheme annotation"

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityScheme.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityScheme.java
@@ -119,4 +119,16 @@ public @interface SecurityScheme {
      * @return URL where OAuth2 configuration values are stored
      **/
     String openIdConnectUrl() default "";
+
+    /**
+     * Reference value to a SecurityScheme object.
+     * <p>
+     * This property provides a reference to an object defined elsewhere. This property and
+     * all other properties are mutually exclusive. If other properties are defined in addition
+     * to the ref property then the result is undefined.
+     *
+     * @return reference to a security scheme
+     **/
+    String ref() default "";
+
 }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/UserResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/UserResource.java
@@ -29,7 +29,6 @@ import org.eclipse.microprofile.openapi.annotations.enums.ParameterStyle;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
-import org.eclipse.microprofile.openapi.annotations.security.SecuritySchemes;
 import org.eclipse.microprofile.openapi.annotations.servers.Server;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.tags.Tags;
@@ -56,23 +55,13 @@ import javax.ws.rs.core.Response;
 
 @Path("/user")
 @Produces({"application/json", "application/xml"})
-@SecuritySchemes(
-    value = {
-        @SecurityScheme(
-            description = "user security scheme",
-            type = SecuritySchemeType.HTTP,
-            securitySchemeName = "httpTestScheme",
-            scheme = "testScheme"),
-        @SecurityScheme(
-            description = "another user security scheme",
-            type = SecuritySchemeType.HTTP,
-            securitySchemeName = "httpTestSchemeWithScope",
-            scheme = "anotherTestScheme"
-        )
-    }
-)
+@SecurityScheme(
+    description = "user security scheme",
+    type = SecuritySchemeType.HTTP,
+    securitySchemeName = "httpTestScheme",
+    scheme = "testScheme")
 @SecurityRequirement(
-    name = "httpTestSchemeWithScope",
+    name = "httpTestScheme",
     scopes = "write:users"
 )
 public class UserResource {
@@ -527,6 +516,9 @@ public class UserResource {
         operationId = "logInUser"
     )
 
+    @SecurityScheme(
+        ref = "#/components/securitySchemes/httpTestScheme"
+    )
     @SecurityRequirement(
         name = "httpTestScheme"
     )


### PR DESCRIPTION
Reverting this PR, as the spec states that securitySchemes can be `Map[string, Security Scheme Object | Reference Object]`

We may need a more realistic test in the TCK that declares a scheme that has a ref, and uses that scheme (by its name) from within a security requirement (or requirement set).  