### PR TITLE
Adding missing POM items

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -74,6 +74,11 @@
                         </goals>
                         <configuration>
                             <backend>html5</backend>
+                            <attributes>
+                                <revnumber>${project.version}</revnumber>
+                                <revremark>${revremark}</revremark>
+                                <revdate>${revisiondate}</revdate>
+                            </attributes>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
These items were missing from the OpenAPI Spec POM when compared with the REST Client Spec POM.

Signed-off-by: Arthur De Magalhaes <ademagalhaes@gmail.com>