### PR TITLE
Address literal 3.0.0 assertions in TCK tests

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 
@@ -54,7 +55,7 @@ public class AirlinesAppTest extends AppTestBase {
     @Test(dataProvider = "formatProvider")
     public void testVersion(String type) {
         ValidatableResponse vr = callEndpoint(type);
-        vr.body("openapi", equalTo("3.0.0"));
+        vr.body("openapi", startsWith("3.0."));
     }
 
     @RunAsClient

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelReaderAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelReaderAppTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 
 import java.util.ArrayList;
@@ -51,7 +52,7 @@ public class ModelReaderAppTest extends AppTestBase {
     @Test(dataProvider = "formatProvider")
     public void testVersion(String type) {
         ValidatableResponse vr = callEndpoint(type);
-        vr.body("openapi", equalTo("3.0.0"));
+        vr.body("openapi", startsWith("3.0."));
     }
 
     @RunAsClient

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassTest.java
@@ -19,6 +19,7 @@ package org.eclipse.microprofile.openapi.tck;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -42,7 +43,7 @@ public class OASConfigExcludeClassTest extends AppTestBase {
     @Test(dataProvider = "formatProvider")
     public void testExcludedClass(String type) throws InterruptedException {
         vr = callEndpoint(type);
-        vr.body("openapi", equalTo("3.0.0"));
+        vr.body("openapi", startsWith("3.0."));
         vr.body("info.title", equalTo("AirlinesRatingApp API"));
         vr.body("info.version", equalTo("1.0"));
         vr.body("paths.", aMapWithSize(11));

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassesTest.java
@@ -18,6 +18,7 @@ package org.eclipse.microprofile.openapi.tck;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -42,7 +43,7 @@ public class OASConfigExcludeClassesTest extends AppTestBase {
     @Test(dataProvider = "formatProvider")
     public void testExcludedClasses(String type) throws InterruptedException {
         vr = callEndpoint(type);
-        vr.body("openapi", equalTo("3.0.0"));
+        vr.body("openapi", startsWith("3.0."));
         vr.body("info.title", equalTo("AirlinesRatingApp API"));
         vr.body("info.version", equalTo("1.0"));
         

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludePackageTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludePackageTest.java
@@ -18,6 +18,7 @@ package org.eclipse.microprofile.openapi.tck;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -42,7 +43,7 @@ public class OASConfigExcludePackageTest extends AppTestBase {
     @Test(dataProvider = "formatProvider")
     public void testExcludePackage(String type) throws InterruptedException {
         vr = callEndpoint(type);
-        vr.body("openapi", equalTo("3.0.0"));
+        vr.body("openapi", startsWith("3.0."));
         vr.body("info.title", equalTo("AirlinesRatingApp API"));
         vr.body("info.version", equalTo("1.0"));
         vr.body("paths", aMapWithSize(14));

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassTest.java
@@ -16,8 +16,8 @@
 
 package org.eclipse.microprofile.openapi.tck;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -42,7 +42,7 @@ public class OASConfigScanClassTest extends AppTestBase {
     @Test(dataProvider = "formatProvider")
     public void testScanClass(String type) throws InterruptedException {
         vr = callEndpoint(type);
-        vr.body("openapi", equalTo("3.0.0"));
+        vr.body("openapi", startsWith("3.0."));
         vr.body("paths", aMapWithSize(5));
         vr.body("paths", hasKey("/reviews"));
         vr.body("paths", hasKey("/reviews/{id}"));

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassesTest.java
@@ -16,8 +16,8 @@
 
 package org.eclipse.microprofile.openapi.tck;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -42,7 +42,7 @@ public class OASConfigScanClassesTest extends AppTestBase {
     @Test(dataProvider = "formatProvider")
     public void testScanClasses(String type) throws InterruptedException {
         vr = callEndpoint(type);
-        vr.body("openapi", equalTo("3.0.0"));
+        vr.body("openapi", startsWith("3.0."));
         vr.body("paths", aMapWithSize(6));
         vr.body("paths", hasKey("/reviews"));
         vr.body("paths", hasKey("/reviews/{id}"));

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanDisableTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanDisableTest.java
@@ -18,6 +18,7 @@ package org.eclipse.microprofile.openapi.tck;
 
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -42,7 +43,7 @@ public class OASConfigScanDisableTest extends AppTestBase {
     @Test(dataProvider = "formatProvider")
     public void testScanDisable(String type) throws InterruptedException {
         vr = callEndpoint(type);
-        vr.body("openapi", equalTo("3.0.0"));
+        vr.body("openapi", startsWith("3.0."));
         vr.body("info.title", equalTo("Liberty APIs"));
         vr.body("info.version", equalTo("1.0"));
         vr.body("paths", aMapWithSize(0));

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanPackageTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanPackageTest.java
@@ -16,8 +16,8 @@
  
 package org.eclipse.microprofile.openapi.tck;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -42,7 +42,7 @@ public class OASConfigScanPackageTest extends AppTestBase {
     @Test(dataProvider = "formatProvider")
     public void testScanPackage(String type) throws InterruptedException {
         vr = callEndpoint(type);
-        vr.body("openapi", equalTo("3.0.0"));
+        vr.body("openapi", startsWith("3.0."));
         vr.body("paths", aMapWithSize(2));
         vr.body("paths", hasKey("/bookings"));
         vr.body("paths", hasKey("/bookings/{id}"));

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/StaticDocumentTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/StaticDocumentTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -49,7 +50,7 @@ public class StaticDocumentTest extends AppTestBase {
     public void testStaticDocument(String type) {
         ValidatableResponse vr = callEndpoint(type);
         
-        vr.body("openapi", equalTo("3.0.0"));
+        vr.body("openapi", startsWith("3.0."));
         
         vr.body("servers", hasSize(1));
         vr.body("servers.find{ it.description == 'MySimpleAPI' }.url",


### PR DESCRIPTION
Fixed all 3.0.0 assertions to allow vendors to set the OAI version to 3.0.x.  Contributes a fix to #177

Signed-off-by: Eric Wittmann <eric.wittmann@gmail.com>