### PR TITLE
Add explicit media type to a callback

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/bookings/BookingResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/bookings/BookingResource.java
@@ -107,6 +107,7 @@ public class BookingResource {
                     responseCode="200",
                     description="Bookings retrieved",
                     content=@Content(
+                        mediaType="application/json",
                         schema=@Schema(
                             type = SchemaType.ARRAY,
                             implementation=Booking.class))


### PR DESCRIPTION
Since Callback responses and request body can have different media type from the method it applies to. Its up to the vendor if the method's or class' @Produces applies in this case so its best to explicitly state mediaType