### PR TITLE
Fixed Endpoint Naming Clash

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/ReviewResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/ReviewResource.java
@@ -202,7 +202,7 @@ public class ReviewResource {
     }
 
     @GET
-    @Path("{user}")
+    @Path("users/{user}")
     @Operation(
         operationId = "getReviewByUser",
         summary="Get all reviews by user")

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/ReviewResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/ReviewResource.java
@@ -247,7 +247,7 @@ public class ReviewResource {
     }
 
     @GET
-    @Path("{airline}")
+    @Path("airlines/{airline}")
     @Operation(
         operationId = "getReviewByAirline",
         summary="Get all reviews by airlines")

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
@@ -220,8 +220,8 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/reviews/{id}'.delete.summary", equalTo("Delete a Review with ID"));
         vr.body("paths.'/reviews/{id}'.delete.operationId", equalTo("deleteReview"));
 
-        vr.body("paths.'/reviews/{user}'.get.summary", equalTo("Get all reviews by user"));
-        vr.body("paths.'/reviews/{user}'.get.operationId", equalTo("getReviewByUser"));
+        vr.body("paths.'/reviews/users/{user}'.get.summary", equalTo("Get all reviews by user"));
+        vr.body("paths.'/reviews/users/{user}'.get.operationId", equalTo("getReviewByUser"));
 
         vr.body("paths.'/reviews/{airline}'.get.summary", equalTo("Get all reviews by airlines"));
         vr.body("paths.'/reviews/{airline}'.get.operationId", equalTo("getReviewByAirline"));
@@ -292,9 +292,9 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/bookings/{id}'.get.responses.'200'.description", equalTo("Booking retrieved"));
         vr.body("paths.'/bookings/{id}'.get.responses.'404'.description", equalTo("Booking not found"));
 
-        vr.body("paths.'/reviews/{user}'.get.responses", aMapWithSize(2));
-        vr.body("paths.'/reviews/{user}'.get.responses.'200'.description", equalTo("Review(s) retrieved"));
-        vr.body("paths.'/reviews/{user}'.get.responses.'404'.description", equalTo("Review(s) not found"));
+        vr.body("paths.'/reviews/users/{user}'.get.responses", aMapWithSize(2));
+        vr.body("paths.'/reviews/users/{user}'.get.responses.'200'.description", equalTo("Review(s) retrieved"));
+        vr.body("paths.'/reviews/users/{user}'.get.responses.'404'.description", equalTo("Review(s) not found"));
 
         vr.body("paths.'/user/{username}'.put.responses", aMapWithSize(3));
         vr.body("paths.'/user/{username}'.put.responses.'200'.description", equalTo("User updated successfully"));
@@ -657,11 +657,11 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("components.examples.review.externalValue", equalTo("http://foo.bar/examples/review-example.json"));
 
         // Example in Parameter Content
-        vr.body("paths.'/reviews/{user}'.get.parameters.find{ it.name=='user'}.content.'*/*'.examples.example.value", equalTo("bsmith"));
+        vr.body("paths.'/reviews/users/{user}'.get.parameters.find{ it.name=='user'}.content.'*/*'.examples.example.value", equalTo("bsmith"));
 
         // Example in Parameter
-        vr.body("paths.'/reviews/{user}'.get.parameters.find{ it.name=='user'}.examples.example1.value", equalTo("bsmith"));
-        vr.body("paths.'/reviews/{user}'.get.parameters.find{ it.name=='user'}.examples.example2.value", equalTo("pat@example.com"));
+        vr.body("paths.'/reviews/users/{user}'.get.parameters.find{ it.name=='user'}.examples.example1.value", equalTo("bsmith"));
+        vr.body("paths.'/reviews/users/{user}'.get.parameters.find{ it.name=='user'}.examples.example2.value", equalTo("pat@example.com"));
     }
 
     @RunAsClient
@@ -698,7 +698,7 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/reviews'.post.tags", containsInAnyOrder("Reviews"));
         vr.body("paths.'/reviews/{id}'.get.tags", containsInAnyOrder("Reviews", "Ratings"));
         vr.body("paths.'/reviews/{id}'.delete.tags", containsInAnyOrder("Reviews", "Ratings"));
-        vr.body("paths.'/reviews/{user}'.get.tags", containsInAnyOrder("Reviews", "Ratings"));
+        vr.body("paths.'/reviews/users/{user}'.get.tags", containsInAnyOrder("Reviews", "Ratings"));
         vr.body("paths.'/reviews/{airline}'.get.tags", containsInAnyOrder("Reviews", "Ratings"));
         vr.body("paths.'/reviews/{user}/{airlines}'.get.tags", containsInAnyOrder("Reviews", "Ratings"));
         vr.body("paths.'/user'.post.tags", containsInAnyOrder("user", "create"));
@@ -855,7 +855,7 @@ public class AirlinesAppTest extends AppTestBase {
     public void testContentInParameter(String type) {
         ValidatableResponse vr = callEndpoint(type);
 
-        String content = "paths.'/reviews/{user}'.get.parameters.find{ it.name == 'user' }.content";
+        String content = "paths.'/reviews/users/{user}'.get.parameters.find{ it.name == 'user' }.content";
         vr.body(content, notNullValue());
         vr.body(content + ".'*/*'", notNullValue());
         vr.body(content + ".'*/*'.schema.type", equalTo("string"));

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
@@ -223,8 +223,8 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/reviews/users/{user}'.get.summary", equalTo("Get all reviews by user"));
         vr.body("paths.'/reviews/users/{user}'.get.operationId", equalTo("getReviewByUser"));
 
-        vr.body("paths.'/reviews/{airline}'.get.summary", equalTo("Get all reviews by airlines"));
-        vr.body("paths.'/reviews/{airline}'.get.operationId", equalTo("getReviewByAirline"));
+        vr.body("paths.'/reviews/airlines/{airline}'.get.summary", equalTo("Get all reviews by airlines"));
+        vr.body("paths.'/reviews/airlines/{airline}'.get.operationId", equalTo("getReviewByAirline"));
 
         vr.body("paths.'/reviews/{user}/{airlines}'.get.summary", equalTo("Get all reviews for an airline by User"));
         vr.body("paths.'/reviews/{user}/{airlines}'.get.operationId", equalTo("getReviewByAirlineAndUser"));
@@ -699,7 +699,7 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/reviews/{id}'.get.tags", containsInAnyOrder("Reviews", "Ratings"));
         vr.body("paths.'/reviews/{id}'.delete.tags", containsInAnyOrder("Reviews", "Ratings"));
         vr.body("paths.'/reviews/users/{user}'.get.tags", containsInAnyOrder("Reviews", "Ratings"));
-        vr.body("paths.'/reviews/{airline}'.get.tags", containsInAnyOrder("Reviews", "Ratings"));
+        vr.body("paths.'/reviews/airlines/{airline}'.get.tags", containsInAnyOrder("Reviews", "Ratings"));
         vr.body("paths.'/reviews/{user}/{airlines}'.get.tags", containsInAnyOrder("Reviews", "Ratings"));
         vr.body("paths.'/user'.post.tags", containsInAnyOrder("user", "create"));
         vr.body("paths.'/user/createWithArray'.post.tags", containsInAnyOrder("user", "create"));

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassTest.java
@@ -49,7 +49,7 @@ public class OASConfigExcludeClassTest extends AppTestBase {
         vr.body("paths.", aMapWithSize(11));
         vr.body("paths.'/reviews'", nullValue());
         vr.body("paths.'/reviews/{id}'", nullValue());
-        vr.body("paths.'/reviews/{user}'", nullValue());
+        vr.body("paths.'/reviews/users/{user}'", nullValue());
         vr.body("paths.'/reviews/{airline}'", nullValue());
         vr.body("paths.'/reviews/{user}/{airlines}'", nullValue());
 

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassTest.java
@@ -50,7 +50,7 @@ public class OASConfigExcludeClassTest extends AppTestBase {
         vr.body("paths.'/reviews'", nullValue());
         vr.body("paths.'/reviews/{id}'", nullValue());
         vr.body("paths.'/reviews/users/{user}'", nullValue());
-        vr.body("paths.'/reviews/{airline}'", nullValue());
+        vr.body("paths.'/reviews/airlines/{airline}'", nullValue());
         vr.body("paths.'/reviews/{user}/{airlines}'", nullValue());
 
         

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassesTest.java
@@ -50,7 +50,7 @@ public class OASConfigExcludeClassesTest extends AppTestBase {
         vr.body("paths.", aMapWithSize(10));
         vr.body("paths.'/reviews'", nullValue());
         vr.body("paths.'/reviews/{id}'", nullValue());
-        vr.body("paths.'/reviews/{user}'", nullValue());
+        vr.body("paths.'/reviews/users/{user}'", nullValue());
         vr.body("paths.'/reviews/{airline}'", nullValue());
         vr.body("paths.'/reviews/{user}/{airlines}'", nullValue());
         

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassesTest.java
@@ -51,7 +51,7 @@ public class OASConfigExcludeClassesTest extends AppTestBase {
         vr.body("paths.'/reviews'", nullValue());
         vr.body("paths.'/reviews/{id}'", nullValue());
         vr.body("paths.'/reviews/users/{user}'", nullValue());
-        vr.body("paths.'/reviews/{airline}'", nullValue());
+        vr.body("paths.'/reviews/airlines/{airline}'", nullValue());
         vr.body("paths.'/reviews/{user}/{airlines}'", nullValue());
         
         vr.body("paths.'/availability'", nullValue());

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassTest.java
@@ -46,13 +46,13 @@ public class OASConfigScanClassTest extends AppTestBase {
         vr.body("paths", aMapWithSize(5));
         vr.body("paths", hasKey("/reviews"));
         vr.body("paths", hasKey("/reviews/{id}"));
-        vr.body("paths", hasKey("/reviews/{user}"));
+        vr.body("paths", hasKey("/reviews/users/{user}"));
         vr.body("paths", hasKey("/reviews/{airline}"));
         vr.body("paths", hasKey("/reviews/{user}/{airlines}"));
         
         vr.body("paths.'/reviews'", aMapWithSize(2));
         vr.body("paths.'/reviews/{id}'", aMapWithSize(2)); 
-        vr.body("paths.'/reviews/{user}'", aMapWithSize(1));
+        vr.body("paths.'/reviews/users/{user}'", aMapWithSize(1));
         vr.body("paths.'/reviews/{airline}'", aMapWithSize(1)); 
         vr.body("paths.'/reviews/{user}/{airlines}'", aMapWithSize(1)); 
         

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassTest.java
@@ -47,13 +47,13 @@ public class OASConfigScanClassTest extends AppTestBase {
         vr.body("paths", hasKey("/reviews"));
         vr.body("paths", hasKey("/reviews/{id}"));
         vr.body("paths", hasKey("/reviews/users/{user}"));
-        vr.body("paths", hasKey("/reviews/{airline}"));
+        vr.body("paths", hasKey("/reviews/airlines/{airline}"));
         vr.body("paths", hasKey("/reviews/{user}/{airlines}"));
         
         vr.body("paths.'/reviews'", aMapWithSize(2));
         vr.body("paths.'/reviews/{id}'", aMapWithSize(2)); 
         vr.body("paths.'/reviews/users/{user}'", aMapWithSize(1));
-        vr.body("paths.'/reviews/{airline}'", aMapWithSize(1)); 
+        vr.body("paths.'/reviews/airlines/{airline}'", aMapWithSize(1)); 
         vr.body("paths.'/reviews/{user}/{airlines}'", aMapWithSize(1)); 
         
         

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassesTest.java
@@ -47,7 +47,7 @@ public class OASConfigScanClassesTest extends AppTestBase {
         vr.body("paths", hasKey("/reviews"));
         vr.body("paths", hasKey("/reviews/{id}"));
         vr.body("paths", hasKey("/reviews/users/{user}"));
-        vr.body("paths", hasKey("/reviews/{airline}"));
+        vr.body("paths", hasKey("/reviews/airlines/{airline}"));
         vr.body("paths", hasKey("/reviews/{user}/{airlines}"));
         
         vr.body("paths", hasKey("/availability"));
@@ -56,7 +56,7 @@ public class OASConfigScanClassesTest extends AppTestBase {
         vr.body("paths.'/reviews'", aMapWithSize(2));
         vr.body("paths.'/reviews/{id}'", aMapWithSize(2)); 
         vr.body("paths.'/reviews/users/{user}'", aMapWithSize(1));
-        vr.body("paths.'/reviews/{airline}'", aMapWithSize(1)); 
+        vr.body("paths.'/reviews/airlines/{airline}'", aMapWithSize(1)); 
         vr.body("paths.'/reviews/{user}/{airlines}'", aMapWithSize(1)); 
         
         vr.body("paths.'/availability'", aMapWithSize(1)); 

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassesTest.java
@@ -46,7 +46,7 @@ public class OASConfigScanClassesTest extends AppTestBase {
         vr.body("paths", aMapWithSize(6));
         vr.body("paths", hasKey("/reviews"));
         vr.body("paths", hasKey("/reviews/{id}"));
-        vr.body("paths", hasKey("/reviews/{user}"));
+        vr.body("paths", hasKey("/reviews/users/{user}"));
         vr.body("paths", hasKey("/reviews/{airline}"));
         vr.body("paths", hasKey("/reviews/{user}/{airlines}"));
         
@@ -55,7 +55,7 @@ public class OASConfigScanClassesTest extends AppTestBase {
         
         vr.body("paths.'/reviews'", aMapWithSize(2));
         vr.body("paths.'/reviews/{id}'", aMapWithSize(2)); 
-        vr.body("paths.'/reviews/{user}'", aMapWithSize(1));
+        vr.body("paths.'/reviews/users/{user}'", aMapWithSize(1));
         vr.body("paths.'/reviews/{airline}'", aMapWithSize(1)); 
         vr.body("paths.'/reviews/{user}/{airlines}'", aMapWithSize(1)); 
         


### PR DESCRIPTION
PR to address issue: https://github.com/eclipse/microprofile-open-api/issues/217.

This change fixes an endpoint path so that the application contains no identical endpoints.