### PR TITLE
Moved META-INF resources into WEB-INF/classes/META-INF

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigWebInf.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigWebInf.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.openapi.tck;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+public class OASConfigWebInf extends OASConfigScanClassTest {
+
+    @Deployment(name = "airlinesWebInf", order = 2)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "airlinesWebInf.war")
+                .addPackages(true, "org.eclipse.microprofile.openapi.apps.airlines")
+                .addAsWebInfResource("class-microprofile-config.properties", "classes/META-INF/microprofile-config.properties");
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigWebInfTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigWebInfTest.java
@@ -20,7 +20,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
-public class OASConfigWebInf extends OASConfigScanClassTest {
+public class OASConfigWebInfTest extends OASConfigScanClassTest {
 
     @Deployment(name = "airlinesWebInf", order = 2)
     public static WebArchive createDeployment() {


### PR DESCRIPTION
PR to address issue: #217.

This change moves resources from `META-INF`, which is not explicitly defined to be correct in the Config API spec, to `WEB-INF/classes/META-INF`, which [is](https://github.com/eclipse/microprofile-config/issues/268).