### PR TITLE
Add missing methods: addHeader(..) and addCallback(..)

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/Operation.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/Operation.java
@@ -280,6 +280,14 @@ public interface Operation extends Constructible, Extensible {
     }
 
     /**
+     * Adds the given callback item to this Operation's list of callbacks.
+     *
+     * @param callback a callback that is applicable for this operation
+     * @return the current Operation object
+     **/
+    Operation addCallback(Callback callback);
+
+    /**
      * Returns the deprecated property from an Operation instance.
      *
      * @return declaration whether this operation is deprecated

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Encoding.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Encoding.java
@@ -111,6 +111,15 @@ public interface Encoding extends Constructible, Extensible {
     void setHeaders(Map<String, Header> headers);
 
     /**
+     * Adds the given header to this Encoding' list of headers with the given string as its key.
+     *
+     * @param key a key conforming to the format required for this object
+     * @param header the header object
+     * @return the current Encoding object
+     */
+    Encoding addHeader(String key, Header header);
+
+    /**
      * Style describes how the encoding value will be serialized depending on the type of the parameter value.
      * <p>
      * This method sets the style property of Encoding instance to the passed style argument and returns the modified instance


### PR DESCRIPTION
As discussed in Issue #229 this PR adds:

```
org.eclipse.microprofile.openapi.models.media.Encoding.addHeader(String, Header)
org.eclipse.microprofile.openapi.models.Operation.addCallback(Callback)
```