### PR TITLE
Fix compile error

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASFactoryErrorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASFactoryErrorTest.java
@@ -38,7 +38,9 @@ public class OASFactoryErrorTest extends Arquillian {
             return null;
         }
         @Override
-        public void addExtension(String name, Object value) {}
+        public License addExtension(String name, Object value) {
+            return null;
+        }
         @Override
         public void setExtensions(Map<String, Object> extensions) {}
         @Override


### PR DESCRIPTION
My PR #250 creates following compile error in the TCK project:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.3.2:compile (default-compile) on project microprofile-openapi-tck: Compilation failure: Compilation failure: 
[ERROR] /___/microprofile-open-api/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASFactoryErrorTest.java:[35,17] error: OASFactoryErrorTest.MyLicenseImpl is not abstract and does not override abstract method addExtension(String,Object) in Extensible
[ERROR] /___/microprofile-open-api/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASFactoryErrorTest.java:[41,20] error: addExtension(String,Object) in OASFactoryErrorTest.MyLicenseImpl cannot implement addExtension(String,Object) in Extensible
[ERROR] 
[ERROR]     T extends Extensible<T> declared in interface Extensible
[ERROR] /___/microprofile-open-api/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASFactoryErrorTest.java:[40,8] error: method does not override or implement a method from a supertype
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :microprofile-openapi-tck
```

I am really sorry about it. I think this was created because I did not use `clean` while using maven locally.