### PR TITLE
 Remove deprecated addApiResponse(String, APIResponse)

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponses.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponses.java
@@ -38,19 +38,6 @@ public interface APIResponses extends Constructible, Extensible<APIResponses>, M
      * @param name the name of APIResponse 
      * @param apiResponse the APIResponse object to be added to APIResponses map
      * @return APIResponses map with the added ApiResponse instance
-     * @deprecated since 1.1, use {@link #addAPIResponse(String, APIResponse)} instead
-     **/
-    @Deprecated
-    default APIResponses addApiResponse(String name, APIResponse apiResponse) {
-        return addAPIResponse(name, apiResponse);
-    }
-
-    /**
-     * Adds an APIResponse in the format of the name as a key and the item as the value to APIResponses map
-     * 
-     * @param name the name of APIResponse 
-     * @param apiResponse the APIResponse object to be added to APIResponses map
-     * @return APIResponses map with the added ApiResponse instance
      **/
     APIResponses addAPIResponse(String name, APIResponse apiResponse);
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponses.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponses.java
@@ -33,13 +33,26 @@ public interface APIResponses extends Constructible, Extensible<APIResponses>, M
     public static final String DEFAULT = "default";
 
     /**
-     * Adds an ApiResponse in the format of the name as a key and the item as the value to ApiResponses map
+     * Adds an APIResponse in the format of the name as a key and the item as the value to APIResponses map
      * 
-     * @param name the name of ApiResponse 
-     * @param apiResponse the ApiResponse object to be added to ApiResponses map
-     * @return ApiResponses map with the added ApiResponse instance
+     * @param name the name of APIResponse 
+     * @param apiResponse the APIResponse object to be added to APIResponses map
+     * @return APIResponses map with the added ApiResponse instance
+     * @deprecated since 1.1, use {@link #addAPIResponse(String, APIResponse)} instead
      **/
-    APIResponses addApiResponse(String name, APIResponse apiResponse);
+    @Deprecated
+    default APIResponses addApiResponse(String name, APIResponse apiResponse) {
+        return addAPIResponse(name, apiResponse);
+    }
+
+    /**
+     * Adds an APIResponse in the format of the name as a key and the item as the value to APIResponses map
+     * 
+     * @param name the name of APIResponse 
+     * @param apiResponse the APIResponse object to be added to APIResponses map
+     * @return APIResponses map with the added ApiResponse instance
+     **/
+    APIResponses addAPIResponse(String name, APIResponse apiResponse);
 
     /**
      * Returns the default documentation of responses other than the ones declared for specific HTTP response codes in this instance of ApiResponses.

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/filter/AirlinesOASFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/filter/AirlinesOASFilter.java
@@ -15,7 +15,6 @@ package org.eclipse.microprofile.openapi.filter;
 
 import org.eclipse.microprofile.openapi.OASFactory;
 import org.eclipse.microprofile.openapi.OASFilter;
-import org.eclipse.microprofile.openapi.models.responses.APIResponses;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.Operation;
 import org.eclipse.microprofile.openapi.models.PathItem;
@@ -26,6 +25,7 @@ import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.models.responses.APIResponse;
+import org.eclipse.microprofile.openapi.models.responses.APIResponses;
 import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
 import org.eclipse.microprofile.openapi.models.servers.Server;
 import org.eclipse.microprofile.openapi.models.tags.Tag;
@@ -38,7 +38,7 @@ public class AirlinesOASFilter implements OASFilter {
             //Add new operation
             pathItem.PUT(OASFactory.createObject(Operation.class).
                     summary("filterPathItem - added put operation")
-                    .responses(OASFactory.createObject(APIResponses.class).addApiResponse("200", 
+                    .responses(OASFactory.createObject(APIResponses.class).addAPIResponse("200", 
                             OASFactory.createObject(APIResponse.class).description("filterPathItem - successfully put airlines"))));
             
             //Spec states : All filterable descendant elements of a filtered element must be called before its ancestor

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/reader/MyOASModelReaderImpl.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/reader/MyOASModelReaderImpl.java
@@ -15,39 +15,38 @@
  */
 package org.eclipse.microprofile.openapi.reader;
 
-import java.util.HashMap;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.math.BigDecimal;
+import java.util.HashMap;
 
 import org.eclipse.microprofile.openapi.OASFactory;
 import org.eclipse.microprofile.openapi.OASModelReader;
-
+import org.eclipse.microprofile.openapi.models.Components;
+import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.Paths;
 import org.eclipse.microprofile.openapi.models.examples.Example;
 import org.eclipse.microprofile.openapi.models.headers.Header;
 import org.eclipse.microprofile.openapi.models.info.Contact;
+import org.eclipse.microprofile.openapi.models.info.Info;
 import org.eclipse.microprofile.openapi.models.info.License;
 import org.eclipse.microprofile.openapi.models.links.Link;
-import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
-import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
-import org.eclipse.microprofile.openapi.models.tags.Tag;
-import org.eclipse.microprofile.openapi.models.Components;
-import org.eclipse.microprofile.openapi.models.OpenAPI;
-import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
-import org.eclipse.microprofile.openapi.models.Paths;
-import org.eclipse.microprofile.openapi.models.Operation;
-import org.eclipse.microprofile.openapi.models.PathItem;
-import org.eclipse.microprofile.openapi.models.info.Info;
 import org.eclipse.microprofile.openapi.models.media.Content;
 import org.eclipse.microprofile.openapi.models.media.MediaType;
 import org.eclipse.microprofile.openapi.models.media.Schema;
-import org.eclipse.microprofile.openapi.models.servers.Server;
-import org.eclipse.microprofile.openapi.models.servers.ServerVariables;
-import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
+import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.models.responses.APIResponse;
 import org.eclipse.microprofile.openapi.models.responses.APIResponses;
 import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
+import org.eclipse.microprofile.openapi.models.servers.Server;
+import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
+import org.eclipse.microprofile.openapi.models.servers.ServerVariables;
+import org.eclipse.microprofile.openapi.models.tags.Tag;
 
 
 public class MyOASModelReaderImpl implements OASModelReader {
@@ -204,7 +203,7 @@ public class MyOASModelReaderImpl implements OASModelReader {
                             .summary("Retrieve all available airlines")
                             .operationId("getAirlines")
                             .responses(OASFactory.createObject(APIResponses.class)
-                                .addApiResponse("404", OASFactory.createObject(APIResponse.class)
+                                .addAPIResponse("404", OASFactory.createObject(APIResponse.class)
                                     .description("No airlines found")
                                     .content(OASFactory.createObject(Content.class)
                                         .addMediaType("n/a", OASFactory.createObject(MediaType.class)))))))
@@ -215,14 +214,14 @@ public class MyOASModelReaderImpl implements OASModelReader {
                             .summary("TEST SUMMARY")
                             .operationId("getTestFlights")
                             .responses(OASFactory.createObject(APIResponses.class)
-                                .addApiResponse("200", OASFactory.createObject(APIResponse.class)
+                                .addAPIResponse("200", OASFactory.createObject(APIResponse.class)
                                     .description("successful operation")
                                     .content(OASFactory.createObject(Content.class)
                                         .addMediaType("application/json", OASFactory.createObject(MediaType.class)
                                             .schema(OASFactory.createObject(Schema.class)
                                                 .type(Schema.SchemaType.ARRAY)
                                                 .ref("#/components.schemas.Flight")))))
-                                .addApiResponse("404", OASFactory.createObject(APIResponse.class)
+                                .addAPIResponse("404", OASFactory.createObject(APIResponse.class)
                                     .description("No available flights found")
                                     .content(OASFactory.createObject(Content.class)
                                         .addMediaType("n/a", OASFactory.createObject(MediaType.class)))))
@@ -276,14 +275,14 @@ public class MyOASModelReaderImpl implements OASModelReader {
                             .summary("Retrieve all bookings for current user")
                             .operationId("getAllBookings")
                             .responses(OASFactory.createObject(APIResponses.class)
-                                .addApiResponse("200", OASFactory.createObject(APIResponse.class)
+                                .addAPIResponse("200", OASFactory.createObject(APIResponse.class)
                                     .description("Bookings retrieved")
                                     .content(OASFactory.createObject(Content.class)
                                         .addMediaType("applictaion/json", OASFactory.createObject(MediaType.class)
                                             .schema(OASFactory.createObject(Schema.class)
                                                 .type(Schema.SchemaType.ARRAY)
                                                 .ref("#/components.schemas.Booking")))))
-                                .addApiResponse("404", OASFactory.createObject(APIResponse.class)
+                                .addAPIResponse("404", OASFactory.createObject(APIResponse.class)
                                     .description("No bookings found for the user"))))
                         .POST(OASFactory.createObject(Operation.class)
                             .security(new ArrayList<SecurityRequirement>())
@@ -293,7 +292,7 @@ public class MyOASModelReaderImpl implements OASModelReader {
                             .description("Create a new booking record with the booking information provided.")
                             .operationId("createBooking")
                             .responses(OASFactory.createObject(APIResponses.class)
-                                .addApiResponse("201", OASFactory.createObject(APIResponse.class)
+                                .addAPIResponse("201", OASFactory.createObject(APIResponse.class)
                                     .description("Bookings created")
                                     .content(OASFactory.createObject(Content.class)
                                         .addMediaType("text/plain", OASFactory.createObject(MediaType.class)

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
@@ -496,7 +496,7 @@ public class ModelConstructionTest extends Arquillian {
         
         final String responseKey = "myResponse";
         final APIResponse responseValue = createConstructibleInstance(APIResponse.class);
-        checkSameObject(responses, responses.addApiResponse(responseKey, responseValue));
+        checkSameObject(responses, responses.addAPIResponse(responseKey, responseValue));
         checkMapEntry(responses, responseKey, responseValue);
         
         final String responseKey2 = "myResponse2";


### PR DESCRIPTION
Follow up from #258 for 2.0 => renamed method is removed.

See Issue #229.