### PR TITLE
Add missing key parameter in Operation#addCallback()

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/Operation.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/Operation.java
@@ -294,12 +294,13 @@ public interface Operation extends Constructible, Extensible<Operation> {
     }
 
     /**
-     * Adds the given callback item to this Operation's list of callbacks.
+     * Adds the given callback item to this Operation's map of callbacks.
      *
+     * @param key a key conforming to the format required for this object
      * @param callback a callback that is applicable for this operation
      * @return the current Operation object
      **/
-    Operation addCallback(Callback callback);
+    Operation addCallback(String key, Callback callback);
 
     /**
      * Returns the deprecated property from an Operation instance.

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
@@ -269,6 +269,11 @@ public class ModelConstructionTest extends Arquillian {
         assertEquals(o.getTags().size(), 1, "The list is expected to contain one entry.");
         o.removeTag(tag);
         assertEquals(o.getTags().size(), 0, "The list is expected to be empty.");
+        
+        final String callbackKey = "myCallback";
+        final Callback callbackValue = createConstructibleInstance(Callback.class);
+        checkSameObject(o, o.addCallback(callbackKey, callbackValue));
+        checkMapEntry(o.getCallbacks(), callbackKey, callbackValue);
     }
     
     @Test


### PR DESCRIPTION
In PR https://github.com/eclipse/microprofile-open-api/pull/249 I have introduced:

```
org.eclipse.microprofile.openapi.models.Operation.addCallback(Callback)
```

But `callbacks` in `Operation` is a `Map<String, Callback>`, so the method should be:

```
org.eclipse.microprofile.openapi.models.Operation.addCallback(String, Callback)
```

This PR adds the missing key parameter.

---

`1.1-SNAPSHOT` was not published yet, so I hope it is OK to fix this now.

---

cc: @EricWittmann, @arthurdm 