### PR TITLE
Add remove methods for lists

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/OpenAPI.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/OpenAPI.java
@@ -142,6 +142,13 @@ public interface OpenAPI extends Constructible, Extensible<OpenAPI> {
     OpenAPI addServer(Server server);
 
     /**
+     * Removes the given server to this OpenAPI instance's list of servers.
+     *
+     * @param server Server object which provides connectivity information to a target server
+     */
+    void removeServer(Server server);
+
+    /**
      * Returns the security property from an OpenAPI instance.
      *
      * @return which security mechanisms can be used across the API
@@ -173,6 +180,13 @@ public interface OpenAPI extends Constructible, Extensible<OpenAPI> {
      * @return the current OpenAPI object
      */
     OpenAPI addSecurityRequirement(SecurityRequirement securityRequirement);
+
+    /**
+     * Removes the given security requirement to this OpenAPI instance's list of security requirements.
+     *
+     * @param securityRequirement security mechanism which can be used across the API
+     */
+    void removeSecurityRequirement(SecurityRequirement securityRequirement);
 
     /**
      * Returns the tags property from an OpenAPI instance.
@@ -207,6 +221,13 @@ public interface OpenAPI extends Constructible, Extensible<OpenAPI> {
      * @return the current OpenAPI object
      */
     OpenAPI addTag(Tag tag);
+
+    /**
+     * Removes the given tag to this OpenAPI instance's list of tags.
+     *
+     * @param tag a tag used by the specification with additional metadata
+     */
+    void removeTag(Tag tag);
 
     /**
      * Returns the paths property from an OpenAPI instance.

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/Operation.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/Operation.java
@@ -72,6 +72,13 @@ public interface Operation extends Constructible, Extensible<Operation> {
     Operation addTag(String tag);
 
     /**
+     * Removes the given tag to this Operation's list of tags.
+     *
+     * @param tag a tag for API documentation control
+     **/
+    void removeTag(String tag);
+
+    /**
      * Returns the summary property from an Operation instance.
      *
      * @return a short summary of what the operation does
@@ -203,6 +210,13 @@ public interface Operation extends Constructible, Extensible<Operation> {
      * @return the current Operation object
      **/
     Operation addParameter(Parameter parameter);
+
+    /**
+     * Removes the given parameter item to this Operation's list of parameters.
+     *
+     * @param parameter a parameter that is applicable for this operation
+     **/
+    void removeParameter(Parameter parameter);
 
     /**
      * Returns the requestBody property from an Operation instance.
@@ -346,6 +360,13 @@ public interface Operation extends Constructible, Extensible<Operation> {
     Operation addSecurityRequirement(SecurityRequirement securityRequirement);
 
     /**
+     * Removes the given security requirement item to this Operation's list of security mechanisms.
+     *
+     * @param securityRequirement security mechanism which can be used for this operation
+     **/
+    void removeSecurityRequirement(SecurityRequirement securityRequirement);
+
+    /**
      * Returns the servers property from an Operation instance.
      *
      * @return a list of servers to service this operation
@@ -377,5 +398,12 @@ public interface Operation extends Constructible, Extensible<Operation> {
      * @return the current Operation object
      **/
     Operation addServer(Server server);
+
+    /**
+     * Removes the given server to this Operation's list of servers.
+     *
+     * @param server server which can service this operation
+     **/
+    void removeServer(Server server);
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/PathItem.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/PathItem.java
@@ -357,6 +357,13 @@ public interface PathItem extends Constructible, Extensible<PathItem>, Reference
     PathItem addServer(Server server);
 
     /**
+     * Removes the given server to this PathItem's list of servers.
+     *
+     * @param server a server to service operations in this path item
+     **/
+    void removeServer(Server server);
+
+    /**
      * Returns the parameters property from this PathItem instance.
      *
      * @return a list of parameters that are applicable to all the operations described under this path
@@ -388,5 +395,12 @@ public interface PathItem extends Constructible, Extensible<PathItem>, Reference
      * @return the current PathItem instance
      **/
     PathItem addParameter(Parameter parameter);
+
+    /**
+     * Removes the given parameter to this PathItem's list of parameters.
+     *
+     * @param parameter a parameter that is applicable to all the operations described under this path
+     **/
+    void removeParameter(Parameter parameter);
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Schema.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Schema.java
@@ -164,6 +164,13 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
     Schema addEnumeration(Object enumeration);
 
     /**
+     * Removes an item of the appropriate type to the enumerated list of values allowed.
+     *
+     * @param enumeration an object to add to the enumerated values
+     */
+    void removeEnumeration(Object enumeration);
+
+    /**
      * Returns the multipleOf property from this Schema instance.
      * <p>
      * minimum: 0
@@ -534,6 +541,13 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
      * @return the current Schema instance
      */
     Schema addRequired(String required);
+
+    /**
+     * Removes the name of an item to the list of fields required in objects defined by this Schema.
+     *
+     * @param required the name of an item required in objects defined by this Schema instance
+     */
+    void removeRequired(String required);
 
     /**
      * Returns the type property from this Schema.
@@ -967,6 +981,13 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
      * @return the current Schema instance
      */
     Schema addAllOf(Schema allOf);
+    
+    /**
+     * Removes the given Schema to the list of schemas used by the allOf property.
+     * 
+     * @param allOf a Schema to use with the allOf property
+     */
+    void removeAllOf(Schema allOf);
 
     /**
      * Returns the schemas used by the anyOf property.
@@ -1002,6 +1023,13 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
     Schema addAnyOf(Schema anyOf);
 
     /**
+     * Removes the given Schema to the list of schemas used by the anyOf property.
+     * 
+     * @param anyOf a Schema to use with the anyOf property
+     */
+    void removeAnyOf(Schema anyOf);
+
+    /**
      * Returns the schemas used by the oneOf property.
      *
      * @return the list of schemas used by the oneOf property
@@ -1033,5 +1061,12 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
      * @return the current Schema instance
      */
     Schema addOneOf(Schema oneOf);
+
+    /**
+     * Removes the given Schema to the list of schemas used by the oneOf property.
+     * 
+     * @param oneOf a Schema to use with the oneOf property
+     */
+    void removeOneOf(Schema oneOf);
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/servers/ServerVariable.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/servers/ServerVariable.java
@@ -71,6 +71,13 @@ public interface ServerVariable extends Constructible, Extensible<ServerVariable
     ServerVariable addEnumeration(String enumeration);
 
     /**
+     * This method removes a string item to enumeration list of a ServerVariable instance.
+     * 
+     * @param enumeration an item to be removed to enum list
+     */
+    void removeEnumeration(String enumeration);
+
+    /**
      * The default value to use for substitution, and to send, if an alternate value is not supplied. This value MUST be provided by the consumer and
      * is REQUIRED.
      * <p>

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
@@ -219,14 +219,23 @@ public class ModelConstructionTest extends Arquillian {
         final SecurityRequirement sr = createConstructibleInstance(SecurityRequirement.class);
         checkSameObject(o, o.addSecurityRequirement(sr));
         checkListEntry(o.getSecurity(), sr);
+        assertEquals(o.getSecurity().size(), 1, "The list is expected to contain one entry.");
+        o.removeSecurityRequirement(sr);
+        assertEquals(o.getSecurity().size(), 0, "The list is expected to be empty.");
         
         final Server s = createConstructibleInstance(Server.class);
         checkSameObject(o, o.addServer(s));
         checkListEntry(o.getServers(), s);
+        assertEquals(o.getServers().size(), 1, "The list is expected to contain one entry.");
+        o.removeServer(s);
+        assertEquals(o.getServers().size(), 0, "The list is expected to be empty.");
         
         final Tag t = createConstructibleInstance(Tag.class);
         checkSameObject(o, o.addTag(t));
         checkListEntry(o.getTags(), t);
+        assertEquals(o.getTags().size(), 1, "The list is expected to contain one entry.");
+        o.removeTag(t);
+        assertEquals(o.getTags().size(), 0, "The list is expected to be empty.");
     }
     
     @Test
@@ -236,18 +245,30 @@ public class ModelConstructionTest extends Arquillian {
         final Parameter p = createConstructibleInstance(Parameter.class);
         checkSameObject(o, o.addParameter(p));
         checkListEntry(o.getParameters(), p);
+        assertEquals(o.getParameters().size(), 1, "The list is expected to contain one entry.");
+        o.removeParameter(p);
+        assertEquals(o.getParameters().size(), 0, "The list is expected to be empty.");
         
         final SecurityRequirement sr = createConstructibleInstance(SecurityRequirement.class);
         checkSameObject(o, o.addSecurityRequirement(sr));
         checkListEntry(o.getSecurity(), sr);
+        assertEquals(o.getSecurity().size(), 1, "The list is expected to contain one entry.");
+        o.removeSecurityRequirement(sr);
+        assertEquals(o.getSecurity().size(), 0, "The list is expected to be empty.");
         
         final Server s = createConstructibleInstance(Server.class);
         checkSameObject(o, o.addServer(s));
         checkListEntry(o.getServers(), s);
+        assertEquals(o.getServers().size(), 1, "The list is expected to contain one entry.");
+        o.removeServer(s);
+        assertEquals(o.getServers().size(), 0, "The list is expected to be empty.");
         
         final String tag = new String("myTag");
         checkSameObject(o, o.addTag(tag));
         checkListEntry(o.getTags(), tag);
+        assertEquals(o.getTags().size(), 1, "The list is expected to contain one entry.");
+        o.removeTag(tag);
+        assertEquals(o.getTags().size(), 0, "The list is expected to be empty.");
     }
     
     @Test
@@ -257,10 +278,16 @@ public class ModelConstructionTest extends Arquillian {
         final Parameter p = createConstructibleInstance(Parameter.class);
         checkSameObject(pi, pi.addParameter(p));
         checkListEntry(pi.getParameters(), p);
+        assertEquals(pi.getParameters().size(), 1, "The list is expected to contain one entry.");
+        pi.removeParameter(p);
+        assertEquals(pi.getParameters().size(), 0, "The list is expected to be empty.");
         
         final Server s = createConstructibleInstance(Server.class);
         checkSameObject(pi, pi.addServer(s));
         checkListEntry(pi.getServers(), s);
+        assertEquals(pi.getServers().size(), 1, "The list is expected to contain one entry.");
+        pi.removeServer(s);
+        assertEquals(pi.getServers().size(), 0, "The list is expected to be empty.");
         
         final Operation o1 = createConstructibleInstance(Operation.class);
         checkSameObject(pi, pi.GET(o1));
@@ -432,18 +459,30 @@ public class ModelConstructionTest extends Arquillian {
         final Schema allOf = createConstructibleInstance(Schema.class);
         checkSameObject(s, s.addAllOf(allOf));
         checkListEntry(s.getAllOf(), allOf);
+        assertEquals(s.getAllOf().size(), 1, "The list is expected to contain one entry.");
+        s.removeAllOf(allOf);
+        assertEquals(s.getAllOf().size(), 0, "The list is expected to be empty.");
         
         final Schema anyOf = createConstructibleInstance(Schema.class);
         checkSameObject(s, s.addAnyOf(anyOf));
         checkListEntry(s.getAnyOf(), anyOf);
+        assertEquals(s.getAnyOf().size(), 1, "The list is expected to contain one entry.");
+        s.removeAnyOf(anyOf);
+        assertEquals(s.getAnyOf().size(), 0, "The list is expected to be empty.");
         
         final String enumeration = new String("enumValue");
         checkSameObject(s, s.addEnumeration(enumeration));
         checkListEntry(s.getEnumeration(), enumeration);
+        assertEquals(s.getEnumeration().size(), 1, "The list is expected to contain one entry.");
+        s.removeEnumeration(enumeration);
+        assertEquals(s.getEnumeration().size(), 0, "The list is expected to be empty.");
         
         final Schema oneOf = createConstructibleInstance(Schema.class);
         checkSameObject(s, s.addOneOf(oneOf));
         checkListEntry(s.getOneOf(), oneOf);
+        assertEquals(s.getOneOf().size(), 1, "The list is expected to contain one entry.");
+        s.removeOneOf(oneOf);
+        assertEquals(s.getOneOf().size(), 0, "The list is expected to be empty.");
         
         final String propertySchemaKey = "myPropertySchemaKey";
         final Schema propertySchemaValue = createConstructibleInstance(Schema.class);
@@ -453,6 +492,9 @@ public class ModelConstructionTest extends Arquillian {
         final String required = new String("required");
         checkSameObject(s, s.addRequired(required));
         checkListEntry(s.getRequired(), required);
+        assertEquals(s.getRequired().size(), 1, "The list is expected to contain one entry.");
+        s.removeRequired(required);
+        assertEquals(s.getRequired().size(), 0, "The list is expected to be empty.");
     }
     
     @Test
@@ -568,6 +610,9 @@ public class ModelConstructionTest extends Arquillian {
         final String enumeration = new String("enumValue");
         checkSameObject(sv, sv.addEnumeration(enumeration));
         checkListEntry(sv.getEnumeration(), enumeration);
+        assertEquals(sv.getEnumeration().size(), 1, "The list is expected to contain one entry.");
+        sv.removeEnumeration(enumeration);
+        assertEquals(sv.getEnumeration().size(), 0, "The list is expected to be empty.");
     }
     
     @Test


### PR DESCRIPTION
See #240, this PRs adds following methods:

Interface `org.eclipse.microprofile.openapi.models.OpenAPI` :
```java
void removeServer(Server)
void removeSecurityRequirement(SecurityRequirement)
void removeTag(Tag)
```


Interface `org.eclipse.microprofile.openapi.models.Operation` :
```java
void removeTag(String)
void removeParameter(Parameter)
void removeSecurityRequirement(SecurityRequirement)
void removeServer(Server)
```


Interface `org.eclipse.microprofile.openapi.models.PathItem` :
```java
void removeServer(Server)
void removeParameter(Parameter)
```


Interface `org.eclipse.microprofile.openapi.models.media.Schema` :
```java
void removeEnumeration(Object)
void removeRequired(String)
void removeAllOf(Schema)
void removeAnyOf(Schema)
void removeOneOf(Schema)
```


Interface `org.eclipse.microprofile.openapi.models.servers.ServerVariable` :
```java
void removeEnumeration(String)
```

And call them in the corresponding test of the TCK: `ModelConstructionTest`.