### PR TITLE
Remove Arquillian feature from ModelConstructionTest

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
@@ -71,10 +71,6 @@ import org.eclipse.microprofile.openapi.models.servers.Server;
 import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
 import org.eclipse.microprofile.openapi.models.servers.ServerVariables;
 import org.eclipse.microprofile.openapi.models.tags.Tag;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
 /**
@@ -82,7 +78,7 @@ import org.testng.annotations.Test;
  * create instances of all of the Constructible interfaces and then invokes methods (including
  * getters, setters and builders) on those instances to verify that they behave correctly.
  */
-public class ModelConstructionTest extends Arquillian {
+public class ModelConstructionTest {
     
     // Container for matched getter, setter and builder methods
     static final class Property {
@@ -150,11 +146,6 @@ public class ModelConstructionTest extends Arquillian {
         public boolean isComplete() {
             return getter != null && setter != null;
         }
-    }
-
-    @Deployment
-    public static WebArchive createDeployment() {
-        return ShrinkWrap.create(WebArchive.class);
     }
 
     @Test


### PR DESCRIPTION
See #270.

This is requested for my use case (I am just implementing the model part of the spec), I can not imagine it breaks other implementations (the one that really have deployments to test), but I am not 100% sure about it.