### PR TITLE
Distinguish Schema and Boolean case for AdditionalProperties in Schema

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Schema.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Schema.java
@@ -638,7 +638,7 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
     /**
      * Returns the value of the "additionalProperties" setting, which indicates whether 
      * properties not otherwise defined are allowed.  This setting MUST either be a {@link Boolean}
-     * or {@link Schema}.
+     * or {@link Schema}, they can not be set both at the same time.
      * 
      * <ul>
      *   <li>If "additionalProperties" is true, then any additional properties are allowed.</li>
@@ -649,48 +649,153 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
      *   <li>If "additionalProperties" is a Schema, then additional properties are allowed but
      *   should conform to the Schema.</li>
      * </ul>
-     *
-     * @return this Schema's additionalProperties property
+     * @deprecated since 1.1, use @link {@link #getAdditionalPropertiesSchema()} or {@link #getAdditionalPropertiesBoolean()} instead
+     * @return a Boolean or a schema
      */
-    Object getAdditionalProperties();
+    @Deprecated
+    default Object getAdditionalProperties() {
+        Schema s = getAdditionalPropertiesSchema();
+        if(s != null) {
+            return s;
+        }
+        return getAdditionalPropertiesBoolean();
+    }
+
+    /**
+     * Returns the value of the "additionalProperties" setting, which indicates whether 
+     * properties not otherwise defined are allowed. This setting MUST either be a {@link Boolean}
+     * or {@link Schema}, they can not be set both at the same time.
+     * <p>
+     * This method returns a {@link Schema}, for the {@link Boolean} getter use {@link #getAdditionalPropertiesBoolean()}
+     * <ul>
+     *   <li>If "additionalProperties" is a Schema, then additional properties are allowed but
+     *   should conform to the Schema.</li>
+     * </ul>
+     * @return this Schema's additionalProperties property (as {@link Schema})
+     */
+    Schema getAdditionalPropertiesSchema();
+
+    /**
+     * Returns the value of the "additionalProperties" setting, which indicates whether 
+     * properties not otherwise defined are allowed. This setting MUST either be a {@link Boolean}
+     * or {@link Schema}, they can not be set both at the same time.
+     * <p>
+     * This method returns a {@link Boolean}, for the {@link Schema} getter use {@link #getAdditionalPropertiesSchema()}
+     * <ul>
+     *   <li>If "additionalProperties" is true, then any additional properties are allowed.</li>
+     *
+     *   <li>If "additionalProperties" is false, then only properties covered by the "properties"
+     *   and "patternProperties" are allowed.</li>
+     * </ul>
+     * @return this Schema's additionalProperties property (as {@link Boolean})
+     */
+    Boolean getAdditionalPropertiesBoolean();
 
     /**
      * Sets the Schema which defines additional properties not defined by "properties" or "patternProperties".
-     * See the javadoc for {@link Schema#getAdditionalProperties()} for more details on this setting.  Note 
-     * that this version of the setter is mutually exclusive with the Boolean variants.
+     * See the javadoc for {@link Schema#getAdditionalPropertiesSchema()} for more details on this setting.  Note 
+     * that this version of the setter is mutually exclusive with the {@link Boolean} variants (see 
+     * {@link #setAdditionalPropertiesBoolean(Boolean)}).
+     *
+     * @deprecated since 1.1, use @link {@link #setAdditionalPropertiesSchema(Schema)} instead
+     * @param additionalProperties a Schema which defines additional properties
+     */
+    @Deprecated
+    default void setAdditionalProperties(Schema additionalProperties) {
+        setAdditionalPropertiesSchema(additionalProperties);
+    }
+
+    /**
+     * Sets the Schema which defines additional properties not defined by "properties" or "patternProperties".
+     * See the javadoc for {@link Schema#getAdditionalPropertiesSchema()} for more details on this setting.  Note 
+     * that this version of the setter is mutually exclusive with the {@link Boolean} variants (see 
+     * {@link #setAdditionalPropertiesBoolean(Boolean)}).
      *
      * @param additionalProperties a Schema which defines additional properties
      */
-    void setAdditionalProperties(Schema additionalProperties);
-    
+    void setAdditionalPropertiesSchema(Schema additionalProperties);
+
     /**
      * Sets the value of "additionalProperties" to either True or False.  See the javadoc for 
-     * {@link Schema#getAdditionalProperties()} for more details on this setting.  Note that
-     * this version of the setter is mutually exclusive with the {@link Schema} variants.
+     * {@link Schema#getAdditionalPropertiesBoolean()} for more details on this setting.  Note that
+     * this version of the setter is mutually exclusive with the {@link Schema} variants (see 
+     * {@link #setAdditionalPropertiesSchema(Schema)}).
+     *
+     * @deprecated since 1.1, use @link {@link #setAdditionalPropertiesBoolean(Boolean)} instead
+     * @param additionalProperties a Schema which defines additional properties
+     */
+    @Deprecated
+    default void setAdditionalProperties(Boolean additionalProperties) {
+        setAdditionalPropertiesBoolean(additionalProperties);
+    }
+
+    /**
+     * Sets the value of "additionalProperties" to either True or False.  See the javadoc for 
+     * {@link Schema#getAdditionalPropertiesBoolean()} for more details on this setting.  Note that
+     * this version of the setter is mutually exclusive with the {@link Schema} variants (see 
+     * {@link #setAdditionalPropertiesSchema(Schema)}).
      *
      * @param additionalProperties a Schema which defines additional properties
      */
-    void setAdditionalProperties(Boolean additionalProperties);
+    void setAdditionalPropertiesBoolean(Boolean additionalProperties);
 
     /**
      * Sets the Schema which defines additional properties not defined by "properties" or "patternProperties".
-     * See the javadoc for {@link Schema#getAdditionalProperties()} for more details on this setting.  Note 
-     * that this version of the setter is mutually exclusive with the Boolean variants.
+     * See the javadoc for {@link Schema#getAdditionalPropertiesSchema()} for more details on this setting.  Note 
+     * that this version of the setter is mutually exclusive with the {@link Boolean} variants (see 
+     * {@link #additionalPropertiesBoolean(Boolean)}).
+     *
+     * @deprecated since 1.1, use @link {@link #additionalPropertiesSchema(Schema)} instead
+     * @param additionalProperties a Schema which defines additional properties
+     * @return the current Schema instance
+     */
+    @Deprecated
+    default Schema additionalProperties(Schema additionalProperties) {
+        return additionalPropertiesSchema(additionalProperties);
+    }
+
+    /**
+     * Sets the Schema which defines additional properties not defined by "properties" or "patternProperties".
+     * See the javadoc for {@link Schema#getAdditionalPropertiesSchema()} for more details on this setting.  Note 
+     * that this version of the setter is mutually exclusive with the {@link Boolean} variants (see 
+     * {@link #additionalPropertiesBoolean(Boolean)}).
      *
      * @param additionalProperties a Schema which defines additional properties
      * @return the current Schema instance
      */
-    Schema additionalProperties(Schema additionalProperties);
+    default Schema additionalPropertiesSchema(Schema additionalProperties) {
+        setAdditionalPropertiesSchema(additionalProperties);
+        return this;
+    }
 
     /**
      * Sets the value of "additionalProperties" to either True or False.  See the javadoc for 
-     * {@link Schema#getAdditionalProperties()} for more details on this setting.  Note that
-     * this version of the setter is mutually exclusive with the {@link Schema} variants.
+     * {@link Schema#getAdditionalPropertiesBoolean()} for more details on this setting.  Note that
+     * this version of the setter is mutually exclusive with the {@link Schema} variants (see 
+     * {@link #additionalPropertiesSchema(Schema)}).
+     *
+     * @deprecated since 1.1, use @link {@link #additionalPropertiesBoolean(Boolean)} instead
+     * @param additionalProperties a Schema which defines additional properties
+     * @return the current Schema instance
+     */
+    @Deprecated
+    default Schema additionalProperties(Boolean additionalProperties) {
+        return additionalPropertiesBoolean(additionalProperties);
+    }
+
+    /**
+     * Sets the value of "additionalProperties" to either True or False.  See the javadoc for 
+     * {@link Schema#getAdditionalPropertiesBoolean()} for more details on this setting.  Note that
+     * this version of the setter is mutually exclusive with the {@link Schema} variants (see 
+     * {@link #additionalPropertiesSchema(Schema)}).
      *
      * @param additionalProperties a Schema which defines additional properties
      * @return the current Schema instance
      */
-    Schema additionalProperties(Boolean additionalProperties);
+    default Schema additionalPropertiesBoolean(Boolean additionalProperties) {
+        setAdditionalPropertiesBoolean(additionalProperties);
+        return this;
+    }
 
     /**
      * Returns a description of the purpose of this Schema.

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
@@ -474,6 +474,20 @@ public class ModelConstructionTest {
     public void schemaTest() {
         final Schema s = processConstructible(Schema.class);
         
+        final Schema ap = createConstructibleInstance(Schema.class);
+        checkSameObject(s, s.additionalPropertiesSchema(ap));
+        checkSameObject(ap, s.getAdditionalPropertiesSchema());
+        assertEquals(s.getAdditionalPropertiesBoolean(), null, "AdditionalProperties (Boolean type) is expected to be null");
+        checkSameObject(s, s.additionalPropertiesBoolean(Boolean.TRUE));
+        assertEquals(s.getAdditionalPropertiesBoolean(), Boolean.TRUE, "AdditionalProperties (Boolean type) is expected to be true");
+        assertEquals(s.getAdditionalPropertiesSchema(), null, "AdditionalProperties (Schema type) is expected to be null");
+        s.setAdditionalPropertiesBoolean(Boolean.FALSE);
+        assertEquals(s.getAdditionalPropertiesBoolean(), Boolean.FALSE, "AdditionalProperties (Boolean type) is expected to be false");
+        assertEquals(s.getAdditionalPropertiesSchema(), null, "AdditionalProperties (Schema type) is expected to be null");
+        s.setAdditionalPropertiesSchema(null);
+        assertEquals(s.getAdditionalPropertiesBoolean(), null, "AdditionalProperties (Boolean type) is expected to be null");
+        assertEquals(s.getAdditionalPropertiesSchema(), null, "AdditionalProperties (Schema type) is expected to be null");
+        
         final Schema allOf = createConstructibleInstance(Schema.class);
         checkSameObject(s, s.addAllOf(allOf));
         checkListEntry(s.getAllOf(), allOf);


### PR DESCRIPTION
See Issue #257.

I think the TCK should test getter/setter/builder for additionalProperties in `ModelConstructionTest.schemaTest()`. I was surprised to see nothing there for the moment.
=> I will add a commit to this PR.