### PR TITLE
Add remove methods for maps

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/Components.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/Components.java
@@ -86,6 +86,13 @@ public interface Components extends Constructible, Extensible<Components> {
     Components addSchema(String key, Schema schema);
 
     /**
+     * Removes the given schema to this Components' list of schemas with the given string as its key.
+     *
+     * @param key a key conforming to the format required for this object
+     */
+    void removeSchema(String key);
+
+    /**
      * Returns the responses property from a Components instance.
      *
      * @return a Map containing the keys and the reusable responses from API operations for this OpenAPI document
@@ -118,6 +125,13 @@ public interface Components extends Constructible, Extensible<Components> {
      * @return the current Components object
      */
     Components addResponse(String key, APIResponse response);
+
+    /**
+     * Removes the given response to this Components' map of responses with the given string as its key.
+     *
+     * @param key a key conforming to the format required for this object
+     */
+    void removeResponse(String key);
 
     /**
      * Returns the parameters property from a Components instance.
@@ -154,6 +168,13 @@ public interface Components extends Constructible, Extensible<Components> {
     Components addParameter(String key, Parameter parameter);
 
     /**
+     * Removes the given parameter to this Components' map of parameters with the given string as its key.
+     *
+     * @param key a key conforming to the format required for this object
+     */
+    void removeParameter(String key);
+
+    /**
      * Returns the examples property from a Components instance.
      *
      * @return a Map containing the keys and the reusable examples for this OpenAPI document
@@ -186,6 +207,13 @@ public interface Components extends Constructible, Extensible<Components> {
      * @return the current Components object
      */
     Components addExample(String key, Example example);
+
+    /**
+     * Removes the given example to this Components' map of examples with the given string as its key.
+     *
+     * @param key a key conforming to the format required for this object
+     */
+    void removeExample(String key);
 
     /**
      * Returns the requestBodies property from a Components instance.
@@ -222,6 +250,13 @@ public interface Components extends Constructible, Extensible<Components> {
     Components addRequestBody(String key, RequestBody requestBody);
 
     /**
+     * Removes the given request body to this Components' map of request bodies with the given string as its key.
+     *
+     * @param key a key conforming to the format required for this object
+     */
+    void removeRequestBody(String key);
+
+    /**
      * Returns the headers property from a Components instance.
      *
      * @return a Map containing the keys and the reusable headers for this OpenAPI document
@@ -254,6 +289,13 @@ public interface Components extends Constructible, Extensible<Components> {
      * @return the current Components object
      */
     Components addHeader(String key, Header header);
+
+    /**
+     * Removes the given header to this Components' map of headers with the given string as its key.
+     *
+     * @param key a key conforming to the format required for this object
+     */
+    void removeHeader(String key);
 
     /**
      * Returns the securitySchemes property from a Components instance.
@@ -290,6 +332,13 @@ public interface Components extends Constructible, Extensible<Components> {
     Components addSecurityScheme(String key, SecurityScheme securityScheme);
 
     /**
+     * Removes the given security scheme to this Components' map of security schemes with the given string as its key.
+     *
+     * @param key a key conforming to the format required for this object
+     */
+    void removeSecurityScheme(String key);
+
+    /**
      * Returns the links property from a Components instance.
      *
      * @return a Map containing the keys and the reusable links for this OpenAPI document
@@ -324,6 +373,13 @@ public interface Components extends Constructible, Extensible<Components> {
     Components addLink(String key, Link link);
 
     /**
+     * Removes the given link to this Components' map of links with the given string as its key.
+     *
+     * @param key a key conforming to the format required for this object
+     */
+    void removeLink(String key);
+
+    /**
      * Returns the callbacks property from a Components instance.
      *
      * @return a Map containing the keys and the reusable callbacks for this OpenAPI document
@@ -356,5 +412,12 @@ public interface Components extends Constructible, Extensible<Components> {
      * @return the current Components object
      */
     Components addCallback(String key, Callback callback);
+
+    /**
+     * Removes the given callback to this Components' map of callbacks with the given string as its key.
+     *
+     * @param key a key conforming to the format required for this object
+     */
+    void removeCallback(String key);
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/Extensible.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/Extensible.java
@@ -52,8 +52,16 @@ public interface Extensible<T extends Extensible<T>> {
      *
      * @param name the key used to access the extension object. Always prefixed by "x-".
      * @param value data not required by the specification
+     * @return the current instance
      */
     T addExtension(String name, Object value);
+
+    /**
+     * Removes the given object to this Extensible's map of extensions, with the given name as its key.
+     *
+     * @param name the key used to access the extension object. Always prefixed by "x-".
+     */
+    void removeExtension(String name);
 
     /**
      * Sets this Extensible's extensions property to the given map of extensions.

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/Operation.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/Operation.java
@@ -303,6 +303,13 @@ public interface Operation extends Constructible, Extensible<Operation> {
     Operation addCallback(String key, Callback callback);
 
     /**
+     * Removes the given callback item to this Operation's map of callbacks.
+     *
+     * @param key a key conforming to the format required for this object
+     **/
+    void removeCallback(String key);
+
+    /**
      * Returns the deprecated property from an Operation instance.
      *
      * @return declaration whether this operation is deprecated

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/headers/Header.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/headers/Header.java
@@ -267,6 +267,13 @@ public interface Header extends Constructible, Extensible<Header>, Reference<Hea
     Header addExample(String key, Example example);
 
     /**
+     * Removes an example of the media type using the specified key to this Header instance.
+     *
+     * @param key string to represent the example
+     */
+    void removeExample(String key);
+
+    /**
      * Returns the example property from a Header instance.
      *
      * @return example of the media type

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/links/Link.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/links/Link.java
@@ -179,6 +179,14 @@ public interface Link extends Constructible, Extensible<Link>, Reference<Link> {
     Link addParameter(String name, Object parameter);
 
     /**
+     * Remove a new parameter to the parameters property of this instance of Link.
+     *
+     * @param name The name of the parameter. Can be qualified using the parameter location [{in}.]{name} for operations that use the same parameter
+     *            name in different locations (e.g. path.id).
+     */
+    void removeParameter(String name);
+
+    /**
      * Returns the description property from a Link instance.
      *
      * @return a description of the link

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Discriminator.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Discriminator.java
@@ -69,6 +69,13 @@ public interface Discriminator extends Constructible {
     Discriminator addMapping(String name, String value);
 
     /**
+     * Remove the given name to the given value and stores it in this Discriminator's mapping property.
+     * 
+     * @param name a key which will be compared to information from a request body or response payload.
+     */
+    void removeMapping(String name);
+
+    /**
      * Sets this Discriminator's mapping property to the given map object.
      *
      * @param mapping a map containing keys and schema names or references

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Encoding.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Encoding.java
@@ -120,6 +120,13 @@ public interface Encoding extends Constructible, Extensible<Encoding> {
     Encoding addHeader(String key, Header header);
 
     /**
+     * Removes the given header to this Encoding' list of headers with the given string as its key.
+     *
+     * @param key a key conforming to the format required for this object
+     */
+    void removeHeader(String key);
+
+    /**
      * Style describes how the encoding value will be serialized depending on the type of the parameter value.
      * <p>
      * This method sets the style property of Encoding instance to the passed style argument and returns the modified instance

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/media/MediaType.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/media/MediaType.java
@@ -97,6 +97,14 @@ public interface MediaType extends Constructible, Extensible<MediaType> {
     MediaType addExample(String key, Example example);
 
     /**
+     * Removes an example item to the examples map of a MediaType instance. The example object should match the media type and specified schema if
+     * present.
+     *
+     * @param key any unique name to identify the example object
+     */
+    void removeExample(String key);
+
+    /**
      * Returns the example property from a MediaType instance.
      *
      * @return an example of the media type
@@ -156,5 +164,12 @@ public interface MediaType extends Constructible, Extensible<MediaType> {
      * @return the current MediaType instance
      */
     MediaType addEncoding(String key, Encoding encodingItem);
+
+    /**
+     * Removes an Encoding item to the encoding property of a MediaType instance.
+     *
+     * @param key a property name in the schema
+     */
+    void removeEncoding(String key);
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Schema.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Schema.java
@@ -636,6 +636,13 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
     Schema addProperty(String key, Schema propertySchema);
 
     /**
+     * Removes a Schema property of the provided name using the given schema.
+     *
+     * @param key the name of a new Schema property
+     */
+    void removeProperty(String key);
+
+    /**
      * Returns the value of the "additionalProperties" setting, which indicates whether 
      * properties not otherwise defined are allowed.  This setting MUST either be a {@link Boolean}
      * or {@link Schema}.

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/parameters/Parameter.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/parameters/Parameter.java
@@ -377,6 +377,14 @@ public interface Parameter extends Constructible, Extensible<Parameter>, Referen
     Parameter addExample(String key, Example example);
 
     /**
+     * Removes an example of the media type using the specified key. The example should contain a value in the correct format as specified in the
+     * parameter encoding.
+     *
+     * @param key string to represent the example
+     */
+    void removeExample(String key);
+
+    /**
      * Returns the example property from a Parameter instance.
      *
      * @return example of the media type

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponse.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponse.java
@@ -103,6 +103,15 @@ public interface APIResponse extends Constructible, Extensible<APIResponse>, Ref
     APIResponse addHeader(String name, Header header);
 
     /**
+     * Removes the given Header to this ApiResponse instance's map of Headers with the given name and return this instance of ApiResponse. If this
+     * ApiResponse instance does not have any headers, a new map is created and the given header is added.
+     *
+     * @param name the unique name of the header
+     */
+
+    void removeHeader(String name);
+
+    /**
      * Returns the map containing descriptions of potential response payload for this instance of ApiResponse.
      *
      * @return the potential content of the response
@@ -167,5 +176,13 @@ public interface APIResponse extends Constructible, Extensible<APIResponse>, Ref
      */
 
     APIResponse addLink(String name, Link link);
+
+    /**
+     * Removes a link to this instance of ApiResponse using the given name and Link.
+     *
+     * @param name the short name of the link
+     */
+    
+    void removeLink(String name);
 
 }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
@@ -157,46 +157,73 @@ public class ModelConstructionTest {
         final Callback callbackValue = createConstructibleInstance(Callback.class);
         checkSameObject(c, c.addCallback(callbackKey, callbackValue));
         checkMapEntry(c.getCallbacks(), callbackKey, callbackValue);
+        assertEquals(c.getCallbacks().size(), 1, "The list is expected to contain one entry.");
+        c.removeCallback(callbackKey);
+        assertEquals(c.getCallbacks().size(), 0, "The list is expected to be empty.");
         
         final String exampleKey = "myExample";
         final Example exampleValue = createConstructibleInstance(Example.class);
         checkSameObject(c, c.addExample(exampleKey, exampleValue));
         checkMapEntry(c.getExamples(), exampleKey, exampleValue);
+        assertEquals(c.getExamples().size(), 1, "The list is expected to contain one entry.");
+        c.removeExample(exampleKey);
+        assertEquals(c.getExamples().size(), 0, "The list is expected to be empty.");
         
         final String headerKey = "myHeader";
         final Header headerValue = createConstructibleInstance(Header.class);
         checkSameObject(c, c.addHeader(headerKey, headerValue));
         checkMapEntry(c.getHeaders(), headerKey, headerValue);
+        assertEquals(c.getHeaders().size(), 1, "The list is expected to contain one entry.");
+        c.removeHeader(headerKey);
+        assertEquals(c.getHeaders().size(), 0, "The list is expected to be empty.");
         
         final String linkKey = "myLink";
         final Link linkValue = createConstructibleInstance(Link.class);
         checkSameObject(c, c.addLink(linkKey, linkValue));
         checkMapEntry(c.getLinks(), linkKey, linkValue);
+        assertEquals(c.getLinks().size(), 1, "The list is expected to contain one entry.");
+        c.removeLink(linkKey);
+        assertEquals(c.getLinks().size(), 0, "The list is expected to be empty.");
         
         final String parameterKey = "myParameter";
         final Parameter parameterValue = createConstructibleInstance(Parameter.class);
         checkSameObject(c, c.addParameter(parameterKey, parameterValue));
         checkMapEntry(c.getParameters(), parameterKey, parameterValue);
+        assertEquals(c.getParameters().size(), 1, "The list is expected to contain one entry.");
+        c.removeParameter(parameterKey);
+        assertEquals(c.getParameters().size(), 0, "The list is expected to be empty.");
         
         final String requestBodyKey = "myRequestBody";
         final RequestBody requestBodyValue = createConstructibleInstance(RequestBody.class);
         checkSameObject(c, c.addRequestBody(requestBodyKey, requestBodyValue));
         checkMapEntry(c.getRequestBodies(), requestBodyKey, requestBodyValue);
+        assertEquals(c.getRequestBodies().size(), 1, "The list is expected to contain one entry.");
+        c.removeRequestBody(requestBodyKey);
+        assertEquals(c.getRequestBodies().size(), 0, "The list is expected to be empty.");
         
         final String responseKey = "myResponse";
         final APIResponse responseValue = createConstructibleInstance(APIResponse.class);
         checkSameObject(c, c.addResponse(responseKey, responseValue));
         checkMapEntry(c.getResponses(), responseKey, responseValue);
+        assertEquals(c.getResponses().size(), 1, "The list is expected to contain one entry.");
+        c.removeResponse(responseKey);
+        assertEquals(c.getResponses().size(), 0, "The list is expected to be empty.");
         
         final String schemaKey = "mySchema";
         final Schema schemaValue = createConstructibleInstance(Schema.class);
         checkSameObject(c, c.addSchema(schemaKey, schemaValue));
         checkMapEntry(c.getSchemas(), schemaKey, schemaValue);
+        assertEquals(c.getSchemas().size(), 1, "The list is expected to contain one entry.");
+        c.removeSchema(schemaKey);
+        assertEquals(c.getSchemas().size(), 0, "The list is expected to be empty.");
         
         final String securitySchemeKey = "mySecurityScheme";
         final SecurityScheme securitySchemeValue = createConstructibleInstance(SecurityScheme.class);
         checkSameObject(c, c.addSecurityScheme(securitySchemeKey, securitySchemeValue));
         checkMapEntry(c.getSecuritySchemes(), securitySchemeKey, securitySchemeValue);
+        assertEquals(c.getSecuritySchemes().size(), 1, "The list is expected to contain one entry.");
+        c.removeSecurityScheme(securitySchemeKey);
+        assertEquals(c.getSecuritySchemes().size(), 0, "The list is expected to be empty.");
     }
     
     @Test
@@ -266,6 +293,9 @@ public class ModelConstructionTest {
         final Callback callbackValue = createConstructibleInstance(Callback.class);
         checkSameObject(o, o.addCallback(callbackKey, callbackValue));
         checkMapEntry(o.getCallbacks(), callbackKey, callbackValue);
+        assertEquals(o.getCallbacks().size(), 1, "The list is expected to contain one entry.");
+        o.removeCallback(callbackKey);
+        assertEquals(o.getCallbacks().size(), 0, "The list is expected to be empty.");
     }
     
     @Test
@@ -396,6 +426,9 @@ public class ModelConstructionTest {
         final Example exampleValue = createConstructibleInstance(Example.class);
         checkSameObject(h, h.addExample(exampleKey, exampleValue));
         checkMapEntry(h.getExamples(), exampleKey, exampleValue);
+        assertEquals(h.getExamples().size(), 1, "The list is expected to contain one entry.");
+        h.removeExample(exampleKey);
+        assertEquals(h.getExamples().size(), 0, "The list is expected to be empty.");
     }
     
     @Test
@@ -421,6 +454,9 @@ public class ModelConstructionTest {
         final String parameterValue = "$request.parameter.id";
         checkSameObject(l, l.addParameter(parameterKey, parameterValue));
         checkMapEntry(l.getParameters(), parameterKey, parameterValue);
+        assertEquals(l.getParameters().size(), 1, "The list is expected to contain one entry.");
+        l.removeParameter(parameterKey);
+        assertEquals(l.getParameters().size(), 0, "The list is expected to be empty.");
     }
     
     @Test
@@ -448,11 +484,22 @@ public class ModelConstructionTest {
         final String value = new String("myValue");
         checkSameObject(d, d.addMapping(key, value));
         checkMapEntry(d.getMapping(), key, value);
+        assertEquals(d.getMapping().size(), 1, "The list is expected to contain one entry.");
+        d.removeMapping(key);
+        assertEquals(d.getMapping().size(), 0, "The list is expected to be empty.");
     }
     
     @Test
     public void encodingTest() {
-        processConstructible(Encoding.class);
+        Encoding e = processConstructible(Encoding.class);
+        
+        final String headerKey = "myHeaderKey";
+        final Header headerValue = createConstructibleInstance(Header.class);
+        checkSameObject(e, e.addHeader(headerKey, headerValue));
+        checkMapEntry(e.getHeaders(), headerKey, headerValue);
+        assertEquals(e.getHeaders().size(), 1, "The list is expected to contain one entry.");
+        e.removeHeader(headerKey);
+        assertEquals(e.getHeaders().size(), 0, "The list is expected to be empty.");
     }
     
     @Test
@@ -463,11 +510,17 @@ public class ModelConstructionTest {
         final Encoding encodingValue = createConstructibleInstance(Encoding.class);
         checkSameObject(mt, mt.addEncoding(encodingKey, encodingValue));
         checkMapEntry(mt.getEncoding(), encodingKey, encodingValue);
+        assertEquals(mt.getEncoding().size(), 1, "The list is expected to contain one entry.");
+        mt.removeEncoding(encodingKey);
+        assertEquals(mt.getEncoding().size(), 0, "The list is expected to be empty.");
         
         final String exampleKey = "myExample";
         final Example exampleValue = createConstructibleInstance(Example.class);
         checkSameObject(mt, mt.addExample(exampleKey, exampleValue));
         checkMapEntry(mt.getExamples(), exampleKey, exampleValue);
+        assertEquals(mt.getExamples().size(), 1, "The list is expected to contain one entry.");
+        mt.removeExample(exampleKey);
+        assertEquals(mt.getExamples().size(), 0, "The list is expected to be empty.");
     }
     
     @Test
@@ -506,6 +559,9 @@ public class ModelConstructionTest {
         final Schema propertySchemaValue = createConstructibleInstance(Schema.class);
         checkSameObject(s, s.addProperty(propertySchemaKey, propertySchemaValue));
         checkMapEntry(s.getProperties(), propertySchemaKey, propertySchemaValue);
+        assertEquals(s.getProperties().size(), 1, "The list is expected to contain one entry.");
+        s.removeProperty(propertySchemaKey);
+        assertEquals(s.getProperties().size(), 0, "The list is expected to be empty.");
         
         final String required = new String("required");
         checkSameObject(s, s.addRequired(required));
@@ -528,6 +584,9 @@ public class ModelConstructionTest {
         final Example exampleValue = createConstructibleInstance(Example.class);
         checkSameObject(p, p.addExample(exampleKey, exampleValue));
         checkMapEntry(p.getExamples(), exampleKey, exampleValue);
+        assertEquals(p.getExamples().size(), 1, "The list is expected to contain one entry.");
+        p.removeExample(exampleKey);
+        assertEquals(p.getExamples().size(), 0, "The list is expected to be empty.");
     }
     
     @Test
@@ -543,11 +602,17 @@ public class ModelConstructionTest {
         final Header headerValue = createConstructibleInstance(Header.class);
         checkSameObject(response, response.addHeader(headerKey, headerValue));
         checkMapEntry(response.getHeaders(), headerKey, headerValue);
+        assertEquals(response.getHeaders().size(), 1, "The list is expected to contain one entry.");
+        response.removeHeader(headerKey);
+        assertEquals(response.getHeaders().size(), 0, "The list is expected to be empty.");
         
         final String linkKey = "myLinkKey";
         final Link linkValue = createConstructibleInstance(Link.class);
         checkSameObject(response, response.addLink(linkKey, linkValue));
         checkMapEntry(response.getLinks(), linkKey, linkValue);
+        assertEquals(response.getLinks().size(), 1, "The list is expected to contain one entry.");
+        response.removeLink(linkKey);
+        assertEquals(response.getLinks().size(), 0, "The list is expected to be empty.");
     }
     
     @Test
@@ -719,6 +784,8 @@ public class ModelConstructionTest {
                 "The value associated with the key: " + extensionName1 + " is expected to be the same one that was added.");
         assertSame(map.get(extensionName2), obj2,
                 "The value associated with the key: " + extensionName2 + " is expected to be the same one that was added.");
+        e.removeExtension(extensionName1);
+        assertEquals(e.getExtensions().size(), 1, "The extensions map is expected to contain one entry.");
         // Check that the extension map can be replaced with the setter and that it is returned by the getter.
         final Map<String, Object> newMap = new HashMap<>();
         e.setExtensions(newMap);

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASFactoryErrorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASFactoryErrorTest.java
@@ -42,6 +42,8 @@ public class OASFactoryErrorTest extends Arquillian {
             return null;
         }
         @Override
+        public void removeExtension(String name) {}
+        @Override
         public void setExtensions(Map<String, Object> extensions) {}
         @Override
         public String getName() {


### PR DESCRIPTION
See https://github.com/eclipse/microprofile-open-api/issues/240

---
This PR adds:

Interface `org.eclipse.microprofile.openapi.models.Components` :
```java
void removeSchema(String)
void removeResponse(String)
void removeParameter(String)
void removeExample(String)
void removeRequestBody(String)
void removeHeader(String)
void removeSecurityScheme(String)
void removeLink(String)
void removeCallback(String)
```


Interface `org.eclipse.microprofile.openapi.models.Operation` :
```java
void removeCallback(String)
```


Interface `org.eclipse.microprofile.openapi.models.headers.Header` :
```java
void removeExample(String)
```


Interface `org.eclipse.microprofile.openapi.models.links.Link` :
```java
void removeParameter(String)
```


Interface `org.eclipse.microprofile.openapi.models.media.Discriminator` :
```java
void removeMapping(String)
```


Interface `org.eclipse.microprofile.openapi.models.media.Encoding` :
```java
void removeHeader(String)
```


Interface `org.eclipse.microprofile.openapi.models.media.MediaType` :
```java
void removeExample(String)
void removeEncoding(String)
```


Interface `org.eclipse.microprofile.openapi.models.media.Schema` :
```java
void removeProperty(String)
```


Interface `org.eclipse.microprofile.openapi.models.parameters.Parameter` :
```java
void removeExample(String)
```


Interface `org.eclipse.microprofile.openapi.models.responses.APIResponse` :
```java
void removeHeader(String)
void removeLink(String)
```
