### PR TITLE
Remove the deprecated getDefault() method in APIResponses

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/OpenAPI.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/OpenAPI.java
@@ -142,6 +142,13 @@ public interface OpenAPI extends Constructible, Extensible<OpenAPI> {
     OpenAPI addServer(Server server);
 
     /**
+     * Removes the given server to this OpenAPI instance's list of servers.
+     *
+     * @param server Server object which provides connectivity information to a target server
+     */
+    void removeServer(Server server);
+
+    /**
      * Returns the security property from an OpenAPI instance.
      *
      * @return which security mechanisms can be used across the API
@@ -173,6 +180,13 @@ public interface OpenAPI extends Constructible, Extensible<OpenAPI> {
      * @return the current OpenAPI object
      */
     OpenAPI addSecurityRequirement(SecurityRequirement securityRequirement);
+
+    /**
+     * Removes the given security requirement to this OpenAPI instance's list of security requirements.
+     *
+     * @param securityRequirement security mechanism which can be used across the API
+     */
+    void removeSecurityRequirement(SecurityRequirement securityRequirement);
 
     /**
      * Returns the tags property from an OpenAPI instance.
@@ -207,6 +221,13 @@ public interface OpenAPI extends Constructible, Extensible<OpenAPI> {
      * @return the current OpenAPI object
      */
     OpenAPI addTag(Tag tag);
+
+    /**
+     * Removes the given tag to this OpenAPI instance's list of tags.
+     *
+     * @param tag a tag used by the specification with additional metadata
+     */
+    void removeTag(Tag tag);
 
     /**
      * Returns the paths property from an OpenAPI instance.

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/Operation.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/Operation.java
@@ -72,6 +72,13 @@ public interface Operation extends Constructible, Extensible<Operation> {
     Operation addTag(String tag);
 
     /**
+     * Removes the given tag to this Operation's list of tags.
+     *
+     * @param tag a tag for API documentation control
+     **/
+    void removeTag(String tag);
+
+    /**
      * Returns the summary property from an Operation instance.
      *
      * @return a short summary of what the operation does
@@ -205,6 +212,13 @@ public interface Operation extends Constructible, Extensible<Operation> {
     Operation addParameter(Parameter parameter);
 
     /**
+     * Removes the given parameter item to this Operation's list of parameters.
+     *
+     * @param parameter a parameter that is applicable for this operation
+     **/
+    void removeParameter(Parameter parameter);
+
+    /**
      * Returns the requestBody property from an Operation instance.
      *
      * @return the request body applicable for this operation
@@ -280,12 +294,13 @@ public interface Operation extends Constructible, Extensible<Operation> {
     }
 
     /**
-     * Adds the given callback item to this Operation's list of callbacks.
+     * Adds the given callback item to this Operation's map of callbacks.
      *
+     * @param key a key conforming to the format required for this object
      * @param callback a callback that is applicable for this operation
      * @return the current Operation object
      **/
-    Operation addCallback(Callback callback);
+    Operation addCallback(String key, Callback callback);
 
     /**
      * Returns the deprecated property from an Operation instance.
@@ -346,6 +361,13 @@ public interface Operation extends Constructible, Extensible<Operation> {
     Operation addSecurityRequirement(SecurityRequirement securityRequirement);
 
     /**
+     * Removes the given security requirement item to this Operation's list of security mechanisms.
+     *
+     * @param securityRequirement security mechanism which can be used for this operation
+     **/
+    void removeSecurityRequirement(SecurityRequirement securityRequirement);
+
+    /**
      * Returns the servers property from an Operation instance.
      *
      * @return a list of servers to service this operation
@@ -377,5 +399,12 @@ public interface Operation extends Constructible, Extensible<Operation> {
      * @return the current Operation object
      **/
     Operation addServer(Server server);
+
+    /**
+     * Removes the given server to this Operation's list of servers.
+     *
+     * @param server server which can service this operation
+     **/
+    void removeServer(Server server);
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/PathItem.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/PathItem.java
@@ -334,6 +334,13 @@ public interface PathItem extends Constructible, Extensible<PathItem>, Reference
     PathItem addServer(Server server);
 
     /**
+     * Removes the given server to this PathItem's list of servers.
+     *
+     * @param server a server to service operations in this path item
+     **/
+    void removeServer(Server server);
+
+    /**
      * Returns the parameters property from this PathItem instance.
      *
      * @return a list of parameters that are applicable to all the operations described under this path
@@ -365,5 +372,12 @@ public interface PathItem extends Constructible, Extensible<PathItem>, Reference
      * @return the current PathItem instance
      **/
     PathItem addParameter(Parameter parameter);
+
+    /**
+     * Removes the given parameter to this PathItem's list of parameters.
+     *
+     * @param parameter a parameter that is applicable to all the operations described under this path
+     **/
+    void removeParameter(Parameter parameter);
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/Paths.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/Paths.java
@@ -40,4 +40,87 @@ public interface Paths extends Constructible, Extensible<Paths>, Map<String, Pat
      */
     Paths addPathItem(String name, PathItem item);
 
+    /**
+     * Adds all the path items to this Paths and return this instance of Paths
+     * 
+     * @param items a map containing the list of paths. Keys MUST begin with a slash.
+     * @return the current Paths instance
+     */
+    Paths addPathItems(Map<String, PathItem> items);
+
+    /**
+     * Removes the given path item to this Paths.
+     * 
+     * @param name a path name that will be removed.
+     */
+    void removePathItem(String name);
+
+    /**
+     * Returns an immutable map of the path items.
+     * 
+     * @return all items
+     */
+    Map<String, PathItem> getPathItems();
+
+    /**
+     * Check whether a path item is present to the map. This is a convenience method for <code>getPathItems().containsKey(name)</code>
+     * 
+     * @param name a path name in the format valid for a Paths object.
+     * @return a boolean to indicate if the path item is present or not.
+     */
+    boolean hasPathItem(String name);
+
+    /**
+     * Returns a path item for a given name. This is a convenience method for <code>getPathItems().get(name)</code>
+     * 
+     * @param name a path name in the format valid for a Paths object.
+     * @return the corresponding path item or null.
+     */
+    PathItem getPathItem(String name);
+
+    /**
+     * In the next version, {@link Paths} will no longer extends {@link Map}, this method will no longer be present.
+     * Use {@link #getPathItem(String)} instead.
+     * @deprecated since 1.1
+     */
+    @Deprecated
+    @Override
+    PathItem get(Object key);
+
+    /**
+     * In the next version, {@link Paths} will no longer extends {@link Map}, this method will no longer be present.
+     * Use {@link #hasPathItem(String)} instead.
+     * @deprecated since 1.1
+     */
+    @Deprecated
+    @Override
+    boolean containsKey(Object key);
+    
+    /**
+     * In the next version, {@link Paths} will no longer extends {@link Map}, this method will no longer be present.
+     * Use {@link #addPathItem(String, PathItem)} instead.
+     * @deprecated since 1.1
+     */
+    @Deprecated
+    @Override
+    PathItem put(String key, PathItem value);
+
+    /**
+     * In the next version, {@link Paths} will no longer extends {@link Map}, this method will no longer be present.
+     * Use {@link #addPathItems(Map)} instead.
+     * @deprecated since 1.1
+     */
+    @Deprecated
+    @Override
+    void putAll(Map<? extends String, ? extends PathItem> m);
+
+    /**
+     * In the next version, {@link Paths} will no longer extends {@link Map}, this method will no longer be present.
+     * Use {@link #removePathItem(String)} instead.
+     * @deprecated since 1.1
+     */
+    @Deprecated
+    @Override
+    PathItem remove(Object key);
+
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Schema.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Schema.java
@@ -164,6 +164,13 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
     Schema addEnumeration(Object enumeration);
 
     /**
+     * Removes an item of the appropriate type to the enumerated list of values allowed.
+     *
+     * @param enumeration an object to add to the enumerated values
+     */
+    void removeEnumeration(Object enumeration);
+
+    /**
      * Returns the multipleOf property from this Schema instance.
      * <p>
      * minimum: 0
@@ -534,6 +541,13 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
      * @return the current Schema instance
      */
     Schema addRequired(String required);
+
+    /**
+     * Removes the name of an item to the list of fields required in objects defined by this Schema.
+     *
+     * @param required the name of an item required in objects defined by this Schema instance
+     */
+    void removeRequired(String required);
 
     /**
      * Returns the type property from this Schema.
@@ -967,6 +981,13 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
      * @return the current Schema instance
      */
     Schema addAllOf(Schema allOf);
+    
+    /**
+     * Removes the given Schema to the list of schemas used by the allOf property.
+     * 
+     * @param allOf a Schema to use with the allOf property
+     */
+    void removeAllOf(Schema allOf);
 
     /**
      * Returns the schemas used by the anyOf property.
@@ -1002,6 +1023,13 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
     Schema addAnyOf(Schema anyOf);
 
     /**
+     * Removes the given Schema to the list of schemas used by the anyOf property.
+     * 
+     * @param anyOf a Schema to use with the anyOf property
+     */
+    void removeAnyOf(Schema anyOf);
+
+    /**
      * Returns the schemas used by the oneOf property.
      *
      * @return the list of schemas used by the oneOf property
@@ -1033,5 +1061,12 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
      * @return the current Schema instance
      */
     Schema addOneOf(Schema oneOf);
+
+    /**
+     * Removes the given Schema to the list of schemas used by the oneOf property.
+     * 
+     * @param oneOf a Schema to use with the oneOf property
+     */
+    void removeOneOf(Schema oneOf);
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponses.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponses.java
@@ -43,24 +43,41 @@ public interface APIResponses extends Constructible, Extensible<APIResponses>, M
 
     /**
      * Returns the default documentation of responses other than the ones declared for specific HTTP response codes in this instance of ApiResponses.
-     *
+     * <p>
+     * Convenience method that is the same as calling {@link #get(Object)} on the map with {@value #DEFAULT} as value for the key.
+     * 
+     * @deprecated since 1.1, use @link {@link #getDefaultValue()} instead
      * @return the default documentation of responses
      **/
+    @Deprecated 
+    default APIResponse getDefault() {
+        return getDefaultValue();
+    }
 
-    APIResponse getDefault();
+    /**
+     * Returns the default documentation of responses other than the ones declared for specific HTTP response codes in this instance of ApiResponses.
+     * <p>
+     * Convenience method that is the same as calling {@link #get(Object)} on the map with {@value #DEFAULT} as value for the key.
+     * 
+     * @return the default documentation of responses
+     **/
+    APIResponse getDefaultValue();
 
     /**
      * Sets the default documentation of responses for this instance of ApiResponses. This will cover all the undeclared responses.
-     *
+     * <p>
+     * Convenience method that is the same as calling {@link #addAPIResponse(String, APIResponse)} with {@value #DEFAULT} as value for the key.
+     * 
      * @param defaultValue the default documentation of responses
      */
-
     void setDefaultValue(APIResponse defaultValue);
 
     /**
      * Sets the default documentation of responses for this instance of ApiResponses and return this instance of ApiResponses. This will cover all the
      * undeclared responses.
-     *
+     * <p>
+     * Convenience method that is the same as calling {@link #addAPIResponse(String, APIResponse)} with {@value #DEFAULT} as value for the key.
+     * 
      * @param defaultValue the default documentation of responses
      * @return this ApiResponses instance
      */

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponses.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponses.java
@@ -46,19 +46,6 @@ public interface APIResponses extends Constructible, Extensible<APIResponses>, M
      * <p>
      * Convenience method that is the same as calling {@link #get(Object)} on the map with {@value #DEFAULT} as value for the key.
      * 
-     * @deprecated since 1.1, use @link {@link #getDefaultValue()} instead
-     * @return the default documentation of responses
-     **/
-    @Deprecated 
-    default APIResponse getDefault() {
-        return getDefaultValue();
-    }
-
-    /**
-     * Returns the default documentation of responses other than the ones declared for specific HTTP response codes in this instance of ApiResponses.
-     * <p>
-     * Convenience method that is the same as calling {@link #get(Object)} on the map with {@value #DEFAULT} as value for the key.
-     * 
      * @return the default documentation of responses
      **/
     APIResponse getDefaultValue();

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/servers/ServerVariable.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/servers/ServerVariable.java
@@ -71,6 +71,13 @@ public interface ServerVariable extends Constructible, Extensible<ServerVariable
     ServerVariable addEnumeration(String enumeration);
 
     /**
+     * This method removes a string item to enumeration list of a ServerVariable instance.
+     * 
+     * @param enumeration an item to be removed to enum list
+     */
+    void removeEnumeration(String enumeration);
+
+    /**
      * The default value to use for substitution, and to send, if an alternate value is not supplied. This value MUST be provided by the consumer and
      * is REQUIRED.
      * <p>

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
@@ -17,6 +17,7 @@
 package org.eclipse.microprofile.openapi.tck;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertNull;
@@ -71,10 +72,6 @@ import org.eclipse.microprofile.openapi.models.servers.Server;
 import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
 import org.eclipse.microprofile.openapi.models.servers.ServerVariables;
 import org.eclipse.microprofile.openapi.models.tags.Tag;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
 /**
@@ -82,7 +79,7 @@ import org.testng.annotations.Test;
  * create instances of all of the Constructible interfaces and then invokes methods (including
  * getters, setters and builders) on those instances to verify that they behave correctly.
  */
-public class ModelConstructionTest extends Arquillian {
+public class ModelConstructionTest {
     
     // Container for matched getter, setter and builder methods
     static final class Property {
@@ -152,11 +149,6 @@ public class ModelConstructionTest extends Arquillian {
         }
     }
 
-    @Deployment
-    public static WebArchive createDeployment() {
-        return ShrinkWrap.create(WebArchive.class);
-    }
-
     @Test
     public void componentsTest() {
         final Components c = processConstructible(Components.class);
@@ -219,14 +211,23 @@ public class ModelConstructionTest extends Arquillian {
         final SecurityRequirement sr = createConstructibleInstance(SecurityRequirement.class);
         checkSameObject(o, o.addSecurityRequirement(sr));
         checkListEntry(o.getSecurity(), sr);
+        assertEquals(o.getSecurity().size(), 1, "The list is expected to contain one entry.");
+        o.removeSecurityRequirement(sr);
+        assertEquals(o.getSecurity().size(), 0, "The list is expected to be empty.");
         
         final Server s = createConstructibleInstance(Server.class);
         checkSameObject(o, o.addServer(s));
         checkListEntry(o.getServers(), s);
+        assertEquals(o.getServers().size(), 1, "The list is expected to contain one entry.");
+        o.removeServer(s);
+        assertEquals(o.getServers().size(), 0, "The list is expected to be empty.");
         
         final Tag t = createConstructibleInstance(Tag.class);
         checkSameObject(o, o.addTag(t));
         checkListEntry(o.getTags(), t);
+        assertEquals(o.getTags().size(), 1, "The list is expected to contain one entry.");
+        o.removeTag(t);
+        assertEquals(o.getTags().size(), 0, "The list is expected to be empty.");
     }
     
     @Test
@@ -236,18 +237,35 @@ public class ModelConstructionTest extends Arquillian {
         final Parameter p = createConstructibleInstance(Parameter.class);
         checkSameObject(o, o.addParameter(p));
         checkListEntry(o.getParameters(), p);
+        assertEquals(o.getParameters().size(), 1, "The list is expected to contain one entry.");
+        o.removeParameter(p);
+        assertEquals(o.getParameters().size(), 0, "The list is expected to be empty.");
         
         final SecurityRequirement sr = createConstructibleInstance(SecurityRequirement.class);
         checkSameObject(o, o.addSecurityRequirement(sr));
         checkListEntry(o.getSecurity(), sr);
+        assertEquals(o.getSecurity().size(), 1, "The list is expected to contain one entry.");
+        o.removeSecurityRequirement(sr);
+        assertEquals(o.getSecurity().size(), 0, "The list is expected to be empty.");
         
         final Server s = createConstructibleInstance(Server.class);
         checkSameObject(o, o.addServer(s));
         checkListEntry(o.getServers(), s);
+        assertEquals(o.getServers().size(), 1, "The list is expected to contain one entry.");
+        o.removeServer(s);
+        assertEquals(o.getServers().size(), 0, "The list is expected to be empty.");
         
         final String tag = new String("myTag");
         checkSameObject(o, o.addTag(tag));
         checkListEntry(o.getTags(), tag);
+        assertEquals(o.getTags().size(), 1, "The list is expected to contain one entry.");
+        o.removeTag(tag);
+        assertEquals(o.getTags().size(), 0, "The list is expected to be empty.");
+        
+        final String callbackKey = "myCallback";
+        final Callback callbackValue = createConstructibleInstance(Callback.class);
+        checkSameObject(o, o.addCallback(callbackKey, callbackValue));
+        checkMapEntry(o.getCallbacks(), callbackKey, callbackValue);
     }
     
     @Test
@@ -257,10 +275,16 @@ public class ModelConstructionTest extends Arquillian {
         final Parameter p = createConstructibleInstance(Parameter.class);
         checkSameObject(pi, pi.addParameter(p));
         checkListEntry(pi.getParameters(), p);
+        assertEquals(pi.getParameters().size(), 1, "The list is expected to contain one entry.");
+        pi.removeParameter(p);
+        assertEquals(pi.getParameters().size(), 0, "The list is expected to be empty.");
         
         final Server s = createConstructibleInstance(Server.class);
         checkSameObject(pi, pi.addServer(s));
         checkListEntry(pi.getServers(), s);
+        assertEquals(pi.getServers().size(), 1, "The list is expected to contain one entry.");
+        pi.removeServer(s);
+        assertEquals(pi.getServers().size(), 0, "The list is expected to be empty.");
         
         final Operation o1 = createConstructibleInstance(Operation.class);
         checkSameObject(pi, pi.GET(o1));
@@ -308,17 +332,38 @@ public class ModelConstructionTest extends Arquillian {
     public void pathsTest() {
         final Paths p = processConstructible(Paths.class);
         
-        final String pathItemKey = "myPathItem";
+        final String pathItemKey = "/myPathItem";
+        assertFalse(p.hasPathItem(pathItemKey), pathItemKey + " is absent in the map");
         final PathItem pathItemValue = createConstructibleInstance(PathItem.class);
         checkSameObject(p, p.addPathItem(pathItemKey, pathItemValue));
+        assertTrue(p.hasPathItem(pathItemKey), pathItemKey + " is present in the map");
+        assertSame(p.getPathItem(pathItemKey), pathItemValue, 
+                "The value associated with the key: " + pathItemKey + " is expected to be the same one that was added.");
         checkMapEntry(p, pathItemKey, pathItemValue);
+        checkMapEntry(p.getPathItems(), pathItemKey, pathItemValue);
         
-        final String pathItemKey2 = "myPathItem2";
+        final String pathItemKey2 = "/myPathItem2";
+        assertFalse(p.hasPathItem(pathItemKey2), pathItemKey2 + " is absent in the map");
         final PathItem pathItemValue2 = createConstructibleInstance(PathItem.class);
         assertNull(p.put(pathItemKey2, pathItemValue2), "No previous mapping expected.");
+        assertTrue(p.hasPathItem(pathItemKey2), pathItemKey2 + " is present in the map");
+        assertSame(p.getPathItem(pathItemKey2), pathItemValue2, 
+                "The value associated with the key: " + pathItemKey2 + " is expected to be the same one that was added.");
         checkMapEntry(p, pathItemKey2, pathItemValue2);
+        checkMapEntry(p.getPathItems(), pathItemKey2, pathItemValue2);
         
         assertEquals(p.size(), 2, "The map is expected to contain two entries.");
+        assertEquals(p.getPathItems().size(), 2, "The map is expected to contain two entries.");
+        
+        p.removePathItem(pathItemKey);
+        assertFalse(p.hasPathItem(pathItemKey), pathItemKey + " is absent in the map");
+        assertEquals(p.size(), 1, "The map is expected to contain two entries.");
+        assertEquals(p.getPathItems().size(), 1, "The map is expected to contain two entries.");
+        
+        p.remove(pathItemKey2);
+        assertFalse(p.hasPathItem(pathItemKey2), pathItemKey + " is absent in the map");
+        assertEquals(p.size(), 0, "The map is expected to contain 0 entries.");
+        assertEquals(p.getPathItems().size(), 0, "The map is expected to contain 0 entries.");
     }
     
     @Test
@@ -432,18 +477,30 @@ public class ModelConstructionTest extends Arquillian {
         final Schema allOf = createConstructibleInstance(Schema.class);
         checkSameObject(s, s.addAllOf(allOf));
         checkListEntry(s.getAllOf(), allOf);
+        assertEquals(s.getAllOf().size(), 1, "The list is expected to contain one entry.");
+        s.removeAllOf(allOf);
+        assertEquals(s.getAllOf().size(), 0, "The list is expected to be empty.");
         
         final Schema anyOf = createConstructibleInstance(Schema.class);
         checkSameObject(s, s.addAnyOf(anyOf));
         checkListEntry(s.getAnyOf(), anyOf);
+        assertEquals(s.getAnyOf().size(), 1, "The list is expected to contain one entry.");
+        s.removeAnyOf(anyOf);
+        assertEquals(s.getAnyOf().size(), 0, "The list is expected to be empty.");
         
         final String enumeration = new String("enumValue");
         checkSameObject(s, s.addEnumeration(enumeration));
         checkListEntry(s.getEnumeration(), enumeration);
+        assertEquals(s.getEnumeration().size(), 1, "The list is expected to contain one entry.");
+        s.removeEnumeration(enumeration);
+        assertEquals(s.getEnumeration().size(), 0, "The list is expected to be empty.");
         
         final Schema oneOf = createConstructibleInstance(Schema.class);
         checkSameObject(s, s.addOneOf(oneOf));
         checkListEntry(s.getOneOf(), oneOf);
+        assertEquals(s.getOneOf().size(), 1, "The list is expected to contain one entry.");
+        s.removeOneOf(oneOf);
+        assertEquals(s.getOneOf().size(), 0, "The list is expected to be empty.");
         
         final String propertySchemaKey = "myPropertySchemaKey";
         final Schema propertySchemaValue = createConstructibleInstance(Schema.class);
@@ -453,6 +510,9 @@ public class ModelConstructionTest extends Arquillian {
         final String required = new String("required");
         checkSameObject(s, s.addRequired(required));
         checkListEntry(s.getRequired(), required);
+        assertEquals(s.getRequired().size(), 1, "The list is expected to contain one entry.");
+        s.removeRequired(required);
+        assertEquals(s.getRequired().size(), 0, "The list is expected to be empty.");
     }
     
     @Test
@@ -494,17 +554,38 @@ public class ModelConstructionTest extends Arquillian {
     public void apiResponsesTest() {
         final APIResponses responses = processConstructible(APIResponses.class);
         
-        final String responseKey = "myResponse";
+        responses.remove(APIResponses.DEFAULT);
+        assertEquals(responses.size(), 0, "The map is expected to contain two entries.");
+        
+        final String responseKey = "200";
         final APIResponse responseValue = createConstructibleInstance(APIResponse.class);
         checkSameObject(responses, responses.addAPIResponse(responseKey, responseValue));
         checkMapEntry(responses, responseKey, responseValue);
         
-        final String responseKey2 = "myResponse2";
+        final String responseKey2 = "4XX";
         final APIResponse responseValue2 = createConstructibleInstance(APIResponse.class);
         assertNull(responses.put(responseKey2, responseValue2), "No previous mapping expected.");
         checkMapEntry(responses, responseKey2, responseValue2);
         
         assertEquals(responses.size(), 2, "The map is expected to contain two entries.");
+        
+        assertNull(responses.getDefaultValue(), "No default value expected.");
+        final String responseKey3 = APIResponses.DEFAULT;
+        final APIResponse responseValue3 = createConstructibleInstance(APIResponse.class);
+        assertNull(responses.put(responseKey3, responseValue3), "No previous mapping expected.");
+        checkMapEntry(responses, responseKey3, responseValue3);
+        checkSameObject(responseValue3, responses.getDefaultValue());
+        
+        assertEquals(responses.size(), 3, "The map is expected to contain two entries.");
+        
+        responses.setDefaultValue(null);
+        assertNull(responses.get(APIResponses.DEFAULT), "No default value expected.");
+        assertNull(responses.getDefaultValue(), "No default value expected.");
+        
+        final APIResponse responseValue4 = createConstructibleInstance(APIResponse.class);
+        responses.setDefaultValue(responseValue4);
+        checkMapEntry(responses, APIResponses.DEFAULT, responseValue4);
+        checkSameObject(responseValue4, responses.getDefaultValue());
     }
     
     @Test
@@ -568,6 +649,9 @@ public class ModelConstructionTest extends Arquillian {
         final String enumeration = new String("enumValue");
         checkSameObject(sv, sv.addEnumeration(enumeration));
         checkListEntry(sv.getEnumeration(), enumeration);
+        assertEquals(sv.getEnumeration().size(), 1, "The list is expected to contain one entry.");
+        sv.removeEnumeration(enumeration);
+        assertEquals(sv.getEnumeration().size(), 0, "The list is expected to be empty.");
     }
     
     @Test
@@ -595,7 +679,7 @@ public class ModelConstructionTest extends Arquillian {
     private <T extends Constructible> T processConstructible(Class<T> clazz) {
         final T o = createConstructibleInstance(clazz);
         if (o instanceof Extensible && Extensible.class.isAssignableFrom(clazz)) {
-            processExtensible((Extensible) o);
+            processExtensible((Extensible<?>) o);
         }
         if (o instanceof Reference && Reference.class.isAssignableFrom(clazz)) {
             processReference((Reference<?>) o);
@@ -619,7 +703,7 @@ public class ModelConstructionTest extends Arquillian {
         return o1;
     }
     
-    private void processExtensible(Extensible e) {
+    private void processExtensible(Extensible<?> e) {
         final String extensionName1 = "x-" + e.getClass().getName() + "-1";
         final Object obj1 = new Object();
         final String extensionName2 = "x-" + e.getClass().getName() + "-2";
@@ -641,6 +725,13 @@ public class ModelConstructionTest extends Arquillian {
         final Map<String, Object> map2 = e.getExtensions();
         assertEquals(map2.size(), 0, "The extensions map is expected to contain no entries.");
         assertSame(map2, newMap, "The return value of getExtensions() is expected to be the same value that was set.");
+        // Check that the extension map can be replaced with the builder method and that it is returned by the getter.
+        final Map<String, Object> newOtherMap = new HashMap<>();
+        newOtherMap.put("x-test", 42);
+        e.setExtensions(newOtherMap);
+        final Map<String, Object> map3 = e.getExtensions();
+        assertEquals(map3.size(), 1, "The extensions map is expected to contain one entry.");
+        assertSame(map3, newOtherMap, "The return value of getExtensions() is expected to be the same value that was set.");
     }
     
     private void processReference(Reference<?> r) {


### PR DESCRIPTION
See Issue #271.
Follow up of #278 (for `2.0`).

This PR removes `APIResponses.getDefault()` which was renamed to `APIResponses.getDefaultValue()` with 1.1.