### PR TITLE
Remove 'extends Map<?,?>' from model classes 

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/Paths.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/Paths.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * 
  * @see <a href= "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#pathsObject"> OpenAPI Specification Paths Object</a>
  */
-public interface Paths extends Constructible, Extensible<Paths>, Map<String, PathItem> {
+public interface Paths extends Constructible, Extensible<Paths> {
 
     /**
      * Adds the given path item to this Paths and return this instance of Paths
@@ -88,50 +88,5 @@ public interface Paths extends Constructible, Extensible<Paths>, Map<String, Pat
         }
         return map.get(name);
     }
-
-    /**
-     * In the next version, {@link Paths} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #getPathItem(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    PathItem get(Object key);
-
-    /**
-     * In the next version, {@link Paths} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #hasPathItem(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    boolean containsKey(Object key);
-    
-    /**
-     * In the next version, {@link Paths} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #addPathItem(String, PathItem)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    PathItem put(String key, PathItem value);
-
-    /**
-     * In the next version, {@link Paths} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #setPathItems(Map)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    void putAll(Map<? extends String, ? extends PathItem> m);
-
-    /**
-     * In the next version, {@link Paths} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #removePathItem(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    PathItem remove(Object key);
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/callbacks/Callback.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/callbacks/Callback.java
@@ -33,7 +33,7 @@ import org.eclipse.microprofile.openapi.models.Reference;
  * 
  * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#callbackObject">OpenAPI Specification Callback Object</a>
  */
-public interface Callback extends Constructible, Extensible<Callback>, Reference<Callback>, Map<String, PathItem> {
+public interface Callback extends Constructible, Extensible<Callback>, Reference<Callback> {
 
     /**
      * Adds the given PathItem to this Callback's list of PathItems using the string as its key.
@@ -96,51 +96,5 @@ public interface Callback extends Constructible, Extensible<Callback>, Reference
         }
         return map.get(name);
     }
-
-    /**
-     * In the next version, {@link Callback} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #getPathItem(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    PathItem get(Object key);
-
-    /**
-     * In the next version, {@link Callback} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #hasPathItem(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    boolean containsKey(Object key);
-    
-    /**
-     * In the next version, {@link Callback} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #addPathItem(String, PathItem)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    PathItem put(String key, PathItem value);
-
-    /**
-     * In the next version, {@link Callback} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #setPathItems(Map)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    void putAll(Map<? extends String, ? extends PathItem> m);
-
-    /**
-     * In the next version, {@link Callback} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #removePathItem(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    PathItem remove(Object key);
-
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Content.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Content.java
@@ -27,7 +27,7 @@ import org.eclipse.microprofile.openapi.models.Constructible;
  * A map to assist describing the media types for an operation's parameter or response.
  * 
  */
-public interface Content extends Constructible, Map<String, MediaType> {
+public interface Content extends Constructible {
 
     /**
      * Adds the MediaType for this Content, where the key is the name of the MediaType and the value is the object that describes the content passed
@@ -87,50 +87,5 @@ public interface Content extends Constructible, Map<String, MediaType> {
         }
         return map.get(name);
     }
-
-    /**
-     * In the next version, {@link Content} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #getMediaType(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    MediaType get(Object key);
-
-    /**
-     * In the next version, {@link Content} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #hasMediaType(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    boolean containsKey(Object key);
-    
-    /**
-     * In the next version, {@link Content} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #addMediaType(String, MediaType)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    MediaType put(String key, MediaType value);
-
-    /**
-     * In the next version, {@link Content} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #setMediaTypes(Map)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    void putAll(Map<? extends String, ? extends MediaType> m);
-
-    /**
-     * In the next version, {@link Content} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #removeMediaType(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    MediaType remove(Object key);
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponses.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponses.java
@@ -28,7 +28,7 @@ import org.eclipse.microprofile.openapi.models.Extensible;
  *
  * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responses-object">Responses Object</a>
  */
-public interface APIResponses extends Constructible, Extensible<APIResponses>, Map<String, APIResponse> {
+public interface APIResponses extends Constructible, Extensible<APIResponses> {
 
     public static final String DEFAULT = "default";
 
@@ -92,54 +92,9 @@ public interface APIResponses extends Constructible, Extensible<APIResponses>, M
     }
 
     /**
-     * In the next version, {@link APIResponses} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #getAPIResponse(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    APIResponse get(Object key);
-
-    /**
-     * In the next version, {@link APIResponses} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #hasAPIResponse(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    boolean containsKey(Object key);
-    
-    /**
-     * In the next version, {@link APIResponses} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #addAPIResponse(String, APIResponse)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    APIResponse put(String key, APIResponse value);
-
-    /**
-     * In the next version, {@link APIResponses} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #setAPIResponses(Map)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    void putAll(Map<? extends String, ? extends APIResponse> m);
-
-    /**
-     * In the next version, {@link APIResponses} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #removeAPIResponse(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    APIResponse remove(Object key);
-
-    /**
      * Returns the default documentation of responses other than the ones declared for specific HTTP response codes in this instance of ApiResponses.
      * <p>
-     * Convenience method that is the same as calling {@link #get(Object)} on the map with {@value #DEFAULT} as value for the key.
+     * Convenience method that is the same as calling {@link #getAPIResponse(String)} on the map with {@value #DEFAULT} as value for the key.
      * 
      * @return the default documentation of responses
      **/

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/security/Scopes.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/security/Scopes.java
@@ -28,7 +28,7 @@ import org.eclipse.microprofile.openapi.models.Extensible;
  * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#oauthFlowObject">OAuthFlow Object</a>
  **/
 
-public interface Scopes extends Constructible, Extensible<Scopes>, Map<String, String> {
+public interface Scopes extends Constructible, Extensible<Scopes> {
 
     /**
      * Adds name of an existing scope object and item parameters to a Scopes instance as a key-value pair in a map.
@@ -87,50 +87,5 @@ public interface Scopes extends Constructible, Extensible<Scopes>, Map<String, S
         }
         return map.get(scope);
     }
-
-    /**
-     * In the next version, {@link Scopes} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #getScope(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    String get(Object key);
-
-    /**
-     * In the next version, {@link Scopes} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #hasScope(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    boolean containsKey(Object key);
-    
-    /**
-     * In the next version, {@link Scopes} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #addScope(String, String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    String put(String key, String value);
-
-    /**
-     * In the next version, {@link Scopes} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #setScopes(Map)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    void putAll(Map<? extends String, ? extends String> m);
-
-    /**
-     * In the next version, {@link Scopes} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #removeScope(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    String remove(Object key);
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/security/SecurityRequirement.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/security/SecurityRequirement.java
@@ -27,7 +27,7 @@ import org.eclipse.microprofile.openapi.models.Constructible;
  *
  * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#security-requirement-object">SecurityRequirement Object</a>
  */
-public interface SecurityRequirement extends Constructible, Map<String, List<String>> {
+public interface SecurityRequirement extends Constructible {
 
     /**
      * Adds a security scheme to the SecurityRequirement instance based on the scheme name and 
@@ -108,50 +108,5 @@ public interface SecurityRequirement extends Constructible, Map<String, List<Str
         }
         return map.get(securitySchemeName);
     }
-
-    /**
-     * In the next version, {@link SecurityRequirement} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #getScheme(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    List<String> get(Object key);
-
-    /**
-     * In the next version, {@link SecurityRequirement} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #hasScheme(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    boolean containsKey(Object key);
-    
-    /**
-     * In the next version, {@link SecurityRequirement} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #addScheme(String, List)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    List<String> put(String key, List<String> value);
-
-    /**
-     * In the next version, {@link SecurityRequirement} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #setSchemes(Map)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    void putAll(Map<? extends String, ? extends List<String>> m);
-
-    /**
-     * In the next version, {@link SecurityRequirement} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #removeScheme(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    List<String> remove(Object key);
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/servers/ServerVariables.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/servers/ServerVariables.java
@@ -27,7 +27,7 @@ import org.eclipse.microprofile.openapi.models.Extensible;
  *
  * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#server-variable-object">ServerVariable Object</a>
  */
-public interface ServerVariables extends Constructible, Extensible<ServerVariables>, Map<String, ServerVariable> {
+public interface ServerVariables extends Constructible, Extensible<ServerVariables> {
 
     /**
      * This method adds a key-value item to a ServerVariables instance from the name-item parameter pair and returns the modified instance.
@@ -86,50 +86,5 @@ public interface ServerVariables extends Constructible, Extensible<ServerVariabl
         }
         return map.get(name);
     }
-
-    /**
-     * In the next version, {@link ServerVariables} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #getServerVariable(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    ServerVariable get(Object key);
-
-    /**
-     * In the next version, {@link ServerVariables} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #hasServerVariable(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    boolean containsKey(Object key);
-    
-    /**
-     * In the next version, {@link ServerVariables} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #addServerVariable(String, ServerVariable)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    ServerVariable put(String key, ServerVariable value);
-
-    /**
-     * In the next version, {@link ServerVariables} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #setServerVariables(Map)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    void putAll(Map<? extends String, ? extends ServerVariable> m);
-
-    /**
-     * In the next version, {@link ServerVariables} will no longer extends {@link Map}, this method will no longer be present.
-     * Use {@link #removeServerVariable(String)} instead.
-     * @deprecated since 1.1
-     */
-    @Deprecated
-    @Override
-    ServerVariable remove(Object key);
 
 }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/filter/AirlinesOASFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/filter/AirlinesOASFilter.java
@@ -55,11 +55,11 @@ public class AirlinesOASFilter implements OASFilter {
             Map<String, Callback> callbacks = pathItem.getPOST().getCallbacks();
             if (callbacks.containsKey("bookingCallback")) {
                 Callback callback = callbacks.get("bookingCallback");
-                if (callback.containsKey("http://localhost:9080/airlines/bookings")
-                        && callback.get("http://localhost:9080/airlines/bookings").getGET() != null) {
-                    if ("child - Retrieve all bookings for current user".equals(callback.get("http://localhost:9080/airlines/bookings")
+                if (callback.hasPathItem("http://localhost:9080/airlines/bookings")
+                        && callback.getPathItem("http://localhost:9080/airlines/bookings").getGET() != null) {
+                    if ("child - Retrieve all bookings for current user".equals(callback.getPathItem("http://localhost:9080/airlines/bookings")
                             .getGET().getDescription())) {   
-                        callback.get("http://localhost:9080/airlines/bookings").getGET()
+                        callback.getPathItem("http://localhost:9080/airlines/bookings").getGET()
                         .setDescription("parent - Retrieve all bookings for current user"); 
                     }
                 }
@@ -127,8 +127,8 @@ public class AirlinesOASFilter implements OASFilter {
         // testing child before parent filtering
         Content content = apiResponse.getContent();
         if (content != null) {
-            if (content.containsKey("application/json")) {
-                Schema schema = content.get("application/json").getSchema();
+            if (content.hasMediaType("application/json")) {
+                Schema schema = content.getMediaType("application/json").getSchema();
                 if ("child - id of the new review".equals(schema.getDescription())) {
                     schema.setDescription("parent - id of the new review");
                 }
@@ -190,13 +190,13 @@ public class AirlinesOASFilter implements OASFilter {
 
     @Override
     public Callback filterCallback(Callback callback) {
-        if(callback.containsKey("{$request.query.callbackUrl}/data") && callback.get("{$request.query.callbackUrl}/data").getPOST() != null){
-            callback.get("{$request.query.callbackUrl}/data").getPOST().setDescription("filterCallback - callback post operation");
+        if(callback.hasPathItem("{$request.query.callbackUrl}/data") && callback.getPathItem("{$request.query.callbackUrl}/data").getPOST() != null){
+            callback.getPathItem("{$request.query.callbackUrl}/data").getPOST().setDescription("filterCallback - callback post operation");
         }
         
-        if (callback.containsKey("http://localhost:9080/airlines/bookings") 
-                && callback.get("http://localhost:9080/airlines/bookings").getGET() != null) {
-            callback.get("http://localhost:9080/airlines/bookings").getGET().setDescription("child - Retrieve all bookings for current user");
+        if (callback.hasPathItem("http://localhost:9080/airlines/bookings") 
+                && callback.getPathItem("http://localhost:9080/airlines/bookings").getGET() != null) {
+            callback.getPathItem("http://localhost:9080/airlines/bookings").getGET().setDescription("child - Retrieve all bookings for current user");
         }
         return callback;
     }
@@ -205,6 +205,6 @@ public class AirlinesOASFilter implements OASFilter {
     public void filterOpenAPI(OpenAPI openAPI) {
         //Spec states : The filterOpenAPI method must be the last method called on a filter (which is just a specialization of the first exception).
         //To ensure that this method is called last, override the operation summary that was previously overridden in filterOperation method
-        openAPI.getPaths().get("/bookings/{id}").getPUT().setSummary("filterOpenAPI - Update a booking with ID");
+        openAPI.getPaths().getPathItem("/bookings/{id}").getPUT().setSummary("filterOpenAPI - Update a booking with ID");
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
@@ -370,30 +370,25 @@ public class ModelConstructionTest {
         assertTrue(p.hasPathItem(pathItemKey), pathItemKey + " is present in the map");
         assertSame(p.getPathItem(pathItemKey), pathItemValue, 
                 "The value associated with the key: " + pathItemKey + " is expected to be the same one that was added.");
-        checkMapEntry(p, pathItemKey, pathItemValue);
         checkMapEntry(p.getPathItems(), pathItemKey, pathItemValue);
         
         final String pathItemKey2 = "/myPathItem2";
         assertFalse(p.hasPathItem(pathItemKey2), pathItemKey2 + " is absent in the map");
         final PathItem pathItemValue2 = createConstructibleInstance(PathItem.class);
-        assertNull(p.put(pathItemKey2, pathItemValue2), "No previous mapping expected.");
+        checkSameObject(p, p.addPathItem(pathItemKey2, pathItemValue2));
         assertTrue(p.hasPathItem(pathItemKey2), pathItemKey2 + " is present in the map");
         assertSame(p.getPathItem(pathItemKey2), pathItemValue2, 
                 "The value associated with the key: " + pathItemKey2 + " is expected to be the same one that was added.");
-        checkMapEntry(p, pathItemKey2, pathItemValue2);
         checkMapEntry(p.getPathItems(), pathItemKey2, pathItemValue2);
         
-        assertEquals(p.size(), 2, "The map is expected to contain two entries.");
         assertEquals(p.getPathItems().size(), 2, "The map is expected to contain two entries.");
         
         p.removePathItem(pathItemKey);
         assertFalse(p.hasPathItem(pathItemKey), pathItemKey + " is absent in the map");
-        assertEquals(p.size(), 1, "The map is expected to contain one entry.");
         assertEquals(p.getPathItems().size(), 1, "The map is expected to contain one entry.");
         
-        p.remove(pathItemKey2);
+        p.removePathItem(pathItemKey2);
         assertFalse(p.hasPathItem(pathItemKey2), pathItemKey + " is absent in the map");
-        assertEquals(p.size(), 0, "The map is expected to contain 0 entries.");
         assertEquals(p.getPathItems().size(), 0, "The map is expected to contain 0 entries.");
         
         final PathItem otherValue = createConstructibleInstance(PathItem.class);
@@ -411,30 +406,25 @@ public class ModelConstructionTest {
         assertTrue(c.hasPathItem(pathItemKey), pathItemKey + " is present in the map");
         assertSame(c.getPathItem(pathItemKey), pathItemValue, 
                 "The value associated with the key: " + pathItemKey + " is expected to be the same one that was added.");
-        checkMapEntry(c, pathItemKey, pathItemValue);
         checkMapEntry(c.getPathItems(), pathItemKey, pathItemValue);
         
         final String pathItemKey2 = "myPathItem2";
         assertFalse(c.hasPathItem(pathItemKey2), pathItemKey2 + " is absent in the map");
         final PathItem pathItemValue2 = createConstructibleInstance(PathItem.class);
-        assertNull(c.put(pathItemKey2, pathItemValue2), "No previous mapping expected.");
+        checkSameObject(c, c.addPathItem(pathItemKey2, pathItemValue2));
         assertTrue(c.hasPathItem(pathItemKey2), pathItemKey2 + " is present in the map");
         assertSame(c.getPathItem(pathItemKey2), pathItemValue2, 
                 "The value associated with the key: " + pathItemKey2 + " is expected to be the same one that was added.");
-        checkMapEntry(c, pathItemKey2, pathItemValue2);
         checkMapEntry(c.getPathItems(), pathItemKey2, pathItemValue2);
         
-        assertEquals(c.size(), 2, "The map is expected to contain two entries.");
         assertEquals(c.getPathItems().size(), 2, "The map is expected to contain two entries.");
         
         c.removePathItem(pathItemKey);
         assertFalse(c.hasPathItem(pathItemKey), pathItemKey + " is absent in the map");
-        assertEquals(c.size(), 1, "The map is expected to contain one entry.");
         assertEquals(c.getPathItems().size(), 1, "The map is expected to contain one entry.");
         
-        c.remove(pathItemKey2);
+        c.removePathItem(pathItemKey2);
         assertFalse(c.hasPathItem(pathItemKey2), pathItemKey + " is absent in the map");
-        assertEquals(c.size(), 0, "The map is expected to contain 0 entries.");
         assertEquals(c.getPathItems().size(), 0, "The map is expected to contain 0 entries.");
         
         final PathItem otherValue = createConstructibleInstance(PathItem.class);
@@ -498,30 +488,25 @@ public class ModelConstructionTest {
         assertTrue(c.hasMediaType(mediaTypeKey), mediaTypeKey + " is present in the map");
         assertSame(c.getMediaType(mediaTypeKey), mediaTypeValue, 
                 "The value associated with the key: " + mediaTypeKey + " is expected to be the same one that was added.");
-        checkMapEntry(c, mediaTypeKey, mediaTypeValue);
         checkMapEntry(c.getMediaTypes(), mediaTypeKey, mediaTypeValue);
         
         final String mediaTypeKey2 = "*/*";
         assertFalse(c.hasMediaType(mediaTypeKey2), mediaTypeKey2 + " is absent in the map");
         final MediaType mediaTypeValue2 = createConstructibleInstance(MediaType.class);
-        assertNull(c.put(mediaTypeKey2, mediaTypeValue2), "No previous mapping expected.");
+        checkSameObject(c, c.addMediaType(mediaTypeKey2, mediaTypeValue2));
         assertTrue(c.hasMediaType(mediaTypeKey2), mediaTypeKey2 + " is present in the map");
         assertSame(c.getMediaType(mediaTypeKey2), mediaTypeValue2, 
                 "The value associated with the key: " + mediaTypeKey2 + " is expected to be the same one that was added.");
-        checkMapEntry(c, mediaTypeKey2, mediaTypeValue2);
         checkMapEntry(c.getMediaTypes(), mediaTypeKey2, mediaTypeValue2);
         
-        assertEquals(c.size(), 2, "The map is expected to contain two entries.");
         assertEquals(c.getMediaTypes().size(), 2, "The map is expected to contain two entries.");
         
         c.removeMediaType(mediaTypeKey);
         assertFalse(c.hasMediaType(mediaTypeKey), mediaTypeKey + " is absent in the map");
-        assertEquals(c.size(), 1, "The map is expected to contain one entry.");
         assertEquals(c.getMediaTypes().size(), 1, "The map is expected to contain one entry.");
         
-        c.remove(mediaTypeKey2);
+        c.removeMediaType(mediaTypeKey2);
         assertFalse(c.hasMediaType(mediaTypeKey2), mediaTypeKey + " is absent in the map");
-        assertEquals(c.size(), 0, "The map is expected to contain 0 entries.");
         assertEquals(c.getMediaTypes().size(), 0, "The map is expected to contain 0 entries.");
         
         final MediaType otherValue = createConstructibleInstance(MediaType.class);
@@ -685,8 +670,10 @@ public class ModelConstructionTest {
     public void apiResponsesTest() {
         final APIResponses responses = processConstructible(APIResponses.class);
         
-        responses.remove(APIResponses.DEFAULT);
-        assertEquals(responses.size(), 0, "The map is expected to contain two entries.");
+        responses.removeAPIResponse(APIResponses.DEFAULT);
+        if(responses.getAPIResponses() != null) {
+            assertEquals(responses.getAPIResponses().size(), 0, "The map is expected to contain two entries.");
+        }
         
         final String responseKey = "200";
         assertFalse(responses.hasAPIResponse(responseKey), responseKey + " is absent in the map");
@@ -695,30 +682,25 @@ public class ModelConstructionTest {
         assertTrue(responses.hasAPIResponse(responseKey), responseKey + " is present in the map");
         assertSame(responses.getAPIResponse(responseKey), pathItemValue, 
                 "The value associated with the key: " + responseKey + " is expected to be the same one that was added.");
-        checkMapEntry(responses, responseKey, pathItemValue);
         checkMapEntry(responses.getAPIResponses(), responseKey, pathItemValue);
         
         final String responseKey2 = "4XX";
         assertFalse(responses.hasAPIResponse(responseKey2), responseKey2 + " is absent in the map");
         final APIResponse pathItemValue2 = createConstructibleInstance(APIResponse.class);
-        assertNull(responses.put(responseKey2, pathItemValue2), "No previous mapping expected.");
+        checkSameObject(responses, responses.addAPIResponse(responseKey2, pathItemValue2));
         assertTrue(responses.hasAPIResponse(responseKey2), responseKey2 + " is present in the map");
         assertSame(responses.getAPIResponse(responseKey2), pathItemValue2, 
                 "The value associated with the key: " + responseKey2 + " is expected to be the same one that was added.");
-        checkMapEntry(responses, responseKey2, pathItemValue2);
         checkMapEntry(responses.getAPIResponses(), responseKey2, pathItemValue2);
         
-        assertEquals(responses.size(), 2, "The map is expected to contain two entries.");
         assertEquals(responses.getAPIResponses().size(), 2, "The map is expected to contain two entries.");
         
         responses.removeAPIResponse(responseKey);
         assertFalse(responses.hasAPIResponse(responseKey), responseKey + " is absent in the map");
-        assertEquals(responses.size(), 1, "The map is expected to contain one entry.");
         assertEquals(responses.getAPIResponses().size(), 1, "The map is expected to contain one entry.");
         
-        responses.remove(responseKey2);
+        responses.removeAPIResponse(responseKey2);
         assertFalse(responses.hasAPIResponse(responseKey2), responseKey + " is absent in the map");
-        assertEquals(responses.size(), 0, "The map is expected to contain 0 entries.");
         assertEquals(responses.getAPIResponses().size(), 0, "The map is expected to contain 0 entries.");
         
         final APIResponse otherValue = createConstructibleInstance(APIResponse.class);
@@ -727,19 +709,19 @@ public class ModelConstructionTest {
         assertNull(responses.getDefaultValue(), "No default value expected.");
         final String responseKey3 = APIResponses.DEFAULT;
         final APIResponse responseValue3 = createConstructibleInstance(APIResponse.class);
-        assertNull(responses.put(responseKey3, responseValue3), "No previous mapping expected.");
-        checkMapEntry(responses, responseKey3, responseValue3);
+        checkSameObject(responses, responses.addAPIResponse(responseKey3, responseValue3));
+        checkMapEntry(responses.getAPIResponses(), responseKey3, responseValue3);
         checkSameObject(responseValue3, responses.getDefaultValue());
         
-        assertEquals(responses.size(), 1, "The map is expected to contain one entry.");
+        assertEquals(responses.getAPIResponses().size(), 1, "The map is expected to contain one entry.");
         
         responses.setDefaultValue(null);
-        assertNull(responses.get(APIResponses.DEFAULT), "No default value expected.");
+        assertNull(responses.getAPIResponse(APIResponses.DEFAULT), "No default value expected.");
         assertNull(responses.getDefaultValue(), "No default value expected.");
         
         final APIResponse responseValue4 = createConstructibleInstance(APIResponse.class);
         responses.setDefaultValue(responseValue4);
-        checkMapEntry(responses, APIResponses.DEFAULT, responseValue4);
+        checkMapEntry(responses.getAPIResponses(), APIResponses.DEFAULT, responseValue4);
         checkSameObject(responseValue4, responses.getDefaultValue());
     }
     
@@ -764,30 +746,25 @@ public class ModelConstructionTest {
         assertTrue(s.hasScope(scopeKey), scopeKey + " is present in the map");
         assertSame(s.getScope(scopeKey), scopeValue, 
                 "The value associated with the key: " + scopeKey + " is expected to be the same one that was added.");
-        checkMapEntry(s, scopeKey, scopeValue);
         checkMapEntry(s.getScopes(), scopeKey, scopeValue);
         
         final String scopeKey2 = "myScope2";
         assertFalse(s.hasScope(scopeKey2), scopeKey2 + " is absent in the map");
         final String scopeValue2 = new String("myDescription2");
-        assertNull(s.put(scopeKey2, scopeValue2), "No previous mapping expected.");
+        checkSameObject(s, s.addScope(scopeKey2, scopeValue2));
         assertTrue(s.hasScope(scopeKey2), scopeKey2 + " is present in the map");
         assertSame(s.getScope(scopeKey2), scopeValue2, 
                 "The value associated with the key: " + scopeKey2 + " is expected to be the same one that was added.");
-        checkMapEntry(s, scopeKey2, scopeValue2);
         checkMapEntry(s.getScopes(), scopeKey2, scopeValue2);
         
-        assertEquals(s.size(), 2, "The map is expected to contain two entries.");
         assertEquals(s.getScopes().size(), 2, "The map is expected to contain two entries.");
         
         s.removeScope(scopeKey);
         assertFalse(s.hasScope(scopeKey), scopeKey + " is absent in the map");
-        assertEquals(s.size(), 1, "The map is expected to contain one entry.");
         assertEquals(s.getScopes().size(), 1, "The map is expected to contain one entry.");
         
-        s.remove(scopeKey2);
+        s.removeScope(scopeKey2);
         assertFalse(s.hasScope(scopeKey2), scopeKey + " is absent in the map");
-        assertEquals(s.size(), 0, "The map is expected to contain 0 entries.");
         assertEquals(s.getScopes().size(), 0, "The map is expected to contain 0 entries.");
         
         final String otherValue = new String("otherDescription");
@@ -805,30 +782,25 @@ public class ModelConstructionTest {
         assertTrue(sr.hasScheme(schemeKey), schemeKey + " is present in the map");
         assertSame(sr.getScheme(schemeKey), schemeValue, 
                 "The value associated with the key: " + schemeKey + " is expected to be the same one that was added.");
-        checkMapEntry(sr, schemeKey, schemeValue);
         checkMapEntry(sr.getSchemes(), schemeKey, schemeValue);
         
         final String schemeKey2 = "myScheme2";
         assertFalse(sr.hasScheme(schemeKey2), schemeKey2 + " is absent in the map");
         final List<String> schemeValue2 = new ArrayList<String>();
-        assertNull(sr.put(schemeKey2, schemeValue2), "No previous mapping expected.");
+        checkSameObject(sr, sr.addScheme(schemeKey2, schemeValue2));
         assertTrue(sr.hasScheme(schemeKey2), schemeKey2 + " is present in the map");
         assertSame(sr.getScheme(schemeKey2), schemeValue2, 
                 "The value associated with the key: " + schemeKey2 + " is expected to be the same one that was added.");
-        checkMapEntry(sr, schemeKey2, schemeValue2);
         checkMapEntry(sr.getSchemes(), schemeKey2, schemeValue2);
         
-        assertEquals(sr.size(), 2, "The map is expected to contain two entries.");
         assertEquals(sr.getSchemes().size(), 2, "The map is expected to contain two entries.");
         
         sr.removeScheme(schemeKey);
         assertFalse(sr.hasScheme(schemeKey), schemeKey + " is absent in the map");
-        assertEquals(sr.size(), 1, "The map is expected to contain one entry.");
         assertEquals(sr.getSchemes().size(), 1, "The map is expected to contain one entry.");
         
-        sr.remove(schemeKey2);
+        sr.removeScheme(schemeKey2);
         assertFalse(sr.hasScheme(schemeKey2), schemeKey + " is absent in the map");
-        assertEquals(sr.size(), 0, "The map is expected to contain 0 entries.");
         assertEquals(sr.getSchemes().size(), 0, "The map is expected to contain 0 entries.");
         
         final List<String> otherValue = new ArrayList<String>();
@@ -868,30 +840,25 @@ public class ModelConstructionTest {
         assertTrue(svs.hasServerVariable(varKey), varKey + " is present in the map");
         assertSame(svs.getServerVariable(varKey), varValue, 
                 "The value associated with the key: " + varKey + " is expected to be the same one that was added.");
-        checkMapEntry(svs, varKey, varValue);
         checkMapEntry(svs.getServerVariables(), varKey, varValue);
         
         final String varKey2 = "myServerVariable2";
         assertFalse(svs.hasServerVariable(varKey2), varKey2 + " is absent in the map");
         final ServerVariable varValue2 = createConstructibleInstance(ServerVariable.class);
-        assertNull(svs.put(varKey2, varValue2), "No previous mapping expected.");
+        checkSameObject(svs, svs.addServerVariable(varKey2, varValue2));
         assertTrue(svs.hasServerVariable(varKey2), varKey2 + " is present in the map");
         assertSame(svs.getServerVariable(varKey2), varValue2, 
                 "The value associated with the key: " + varKey2 + " is expected to be the same one that was added.");
-        checkMapEntry(svs, varKey2, varValue2);
         checkMapEntry(svs.getServerVariables(), varKey2, varValue2);
         
-        assertEquals(svs.size(), 2, "The map is expected to contain two entries.");
         assertEquals(svs.getServerVariables().size(), 2, "The map is expected to contain two entries.");
         
         svs.removeServerVariable(varKey);
         assertFalse(svs.hasServerVariable(varKey), varKey + " is absent in the map");
-        assertEquals(svs.size(), 1, "The map is expected to contain one entry.");
         assertEquals(svs.getServerVariables().size(), 1, "The map is expected to contain one entry.");
         
-        svs.remove(varKey2);
+        svs.removeServerVariable(varKey2);
         assertFalse(svs.hasServerVariable(varKey2), varKey + " is absent in the map");
-        assertEquals(svs.size(), 0, "The map is expected to contain 0 entries.");
         assertEquals(svs.getServerVariables().size(), 0, "The map is expected to contain 0 entries.");
         
         final ServerVariable otherValue = createConstructibleInstance(ServerVariable.class);


### PR DESCRIPTION
* merge `master` into `2.0`
* remove `extends Map<..,..>` from  following model classes :
  * Paths
  * Callback
  * Content
  * APIResponses
  * Scopes
  * SecurityRequirement
  * ServerVariables

See Issue #248, follow up of #283 for the `2.0` branch