### PR TITLE
(2.0) Ensure map and list getters returns an (immutable) copy

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/Components.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/Components.java
@@ -54,7 +54,7 @@ public interface Components extends Constructible, Extensible<Components> {
     /**
      * Returns the schemas property from a Components instance.
      *
-     * @return a Map containing the keys and the reusable schemas for this OpenAPI document
+     * @return a copy Map (potentially immutable) containing the keys and the reusable schemas for this OpenAPI document
      **/
     Map<String, Schema> getSchemas();
 
@@ -95,7 +95,7 @@ public interface Components extends Constructible, Extensible<Components> {
     /**
      * Returns the responses property from a Components instance.
      *
-     * @return a Map containing the keys and the reusable responses from API operations for this OpenAPI document
+     * @return a copy Map (potentially immutable) containing the keys and the reusable responses from API operations for this OpenAPI document
      **/
     Map<String, APIResponse> getResponses();
 
@@ -136,7 +136,7 @@ public interface Components extends Constructible, Extensible<Components> {
     /**
      * Returns the parameters property from a Components instance.
      *
-     * @return a Map containing the keys and the reusable parameters of API operations for this OpenAPI document
+     * @return a copy Map (potentially immutable) containing the keys and the reusable parameters of API operations for this OpenAPI document
      **/
     Map<String, Parameter> getParameters();
 
@@ -177,7 +177,7 @@ public interface Components extends Constructible, Extensible<Components> {
     /**
      * Returns the examples property from a Components instance.
      *
-     * @return a Map containing the keys and the reusable examples for this OpenAPI document
+     * @return a copy Map (potentially immutable) containing the keys and the reusable examples for this OpenAPI document
      **/
     Map<String, Example> getExamples();
 
@@ -218,7 +218,7 @@ public interface Components extends Constructible, Extensible<Components> {
     /**
      * Returns the requestBodies property from a Components instance.
      *
-     * @return a Map containing the keys and the reusable request bodies for this OpenAPI document
+     * @return a copy Map (potentially immutable) containing the keys and the reusable request bodies for this OpenAPI document
      **/
     Map<String, RequestBody> getRequestBodies();
 
@@ -259,7 +259,7 @@ public interface Components extends Constructible, Extensible<Components> {
     /**
      * Returns the headers property from a Components instance.
      *
-     * @return a Map containing the keys and the reusable headers for this OpenAPI document
+     * @return a copy Map (potentially immutable) containing the keys and the reusable headers for this OpenAPI document
      **/
     Map<String, Header> getHeaders();
 
@@ -300,7 +300,7 @@ public interface Components extends Constructible, Extensible<Components> {
     /**
      * Returns the securitySchemes property from a Components instance.
      *
-     * @return a Map containing the keys and the reusable security schemes for this OpenAPI document
+     * @return a copy Map (potentially immutable) containing the keys and the reusable security schemes for this OpenAPI document
      **/
     Map<String, SecurityScheme> getSecuritySchemes();
 
@@ -341,7 +341,7 @@ public interface Components extends Constructible, Extensible<Components> {
     /**
      * Returns the links property from a Components instance.
      *
-     * @return a Map containing the keys and the reusable links for this OpenAPI document
+     * @return a copy Map (potentially immutable) containing the keys and the reusable links for this OpenAPI document
      **/
     Map<String, Link> getLinks();
 
@@ -382,7 +382,7 @@ public interface Components extends Constructible, Extensible<Components> {
     /**
      * Returns the callbacks property from a Components instance.
      *
-     * @return a Map containing the keys and the reusable callbacks for this OpenAPI document
+     * @return a copy Map (potentially immutable) containing the keys and the reusable callbacks for this OpenAPI document
      **/
     Map<String, Callback> getCallbacks();
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/OpenAPI.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/OpenAPI.java
@@ -111,7 +111,7 @@ public interface OpenAPI extends Constructible, Extensible<OpenAPI> {
     /**
      * Returns the Servers defined in the API
      *
-     * @return Server objects which provide connectivity information to target servers
+     * @return a copy List (potentially immutable) of Server objects which provide connectivity information to target servers
      **/
     List<Server> getServers();
 
@@ -151,7 +151,7 @@ public interface OpenAPI extends Constructible, Extensible<OpenAPI> {
     /**
      * Returns the security property from an OpenAPI instance.
      *
-     * @return which security mechanisms can be used across the API
+     * @return a copy List (potentially immutable) containing the security mechanisms that can be used across the API
      **/
     List<SecurityRequirement> getSecurity();
 
@@ -191,7 +191,7 @@ public interface OpenAPI extends Constructible, Extensible<OpenAPI> {
     /**
      * Returns the tags property from an OpenAPI instance.
      *
-     * @return tags used by the specification
+     * @return a copy List (potentially immutable) of tags defined in this the specification
      **/
 
     List<Tag> getTags();

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/Operation.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/Operation.java
@@ -41,7 +41,7 @@ public interface Operation extends Constructible, Extensible<Operation> {
     /**
      * Returns the tags property from an Operation instance.
      *
-     * @return a list of the operation's tags
+     * @return a copy List (potentially immutable) of the operation's tags
      **/
     List<String> getTags();
 
@@ -181,7 +181,7 @@ public interface Operation extends Constructible, Extensible<Operation> {
     /**
      * Returns the parameters property from an Operation instance.
      *
-     * @return a list of parameters that are applicable for this operation
+     * @return a copy List (potentially immutable) of parameters that are applicable for this operation
      **/
     List<Parameter> getParameters();
 
@@ -271,7 +271,7 @@ public interface Operation extends Constructible, Extensible<Operation> {
     /**
      * Returns the callbacks property from an Operation instance.
      *
-     * @return map of possible out-of-band callbacks related to the operation
+     * @return a copy Map (potentially immutable) of possible out-of-band callbacks related to the operation
      **/
     Map<String, Callback> getCallbacks();
 
@@ -337,7 +337,7 @@ public interface Operation extends Constructible, Extensible<Operation> {
     /**
      * Returns the security property from an Operation instance.
      *
-     * @return a list of which security mechanisms can be used for this operation
+     * @return a copy List (potentially immutable) of which security mechanisms can be used for this operation
      **/
     List<SecurityRequirement> getSecurity();
 
@@ -377,7 +377,7 @@ public interface Operation extends Constructible, Extensible<Operation> {
     /**
      * Returns the servers property from an Operation instance.
      *
-     * @return a list of servers to service this operation
+     * @return a copy List (potentially immutable) of servers to service this operation
      **/
     List<Server> getServers();
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/PathItem.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/PathItem.java
@@ -303,7 +303,7 @@ public interface PathItem extends Constructible, Extensible<PathItem>, Reference
     /**
      * Returns the servers property from a PathItem instance.
      *
-     * @return a list of all the servers defined in this path item
+     * @return a copy List (potentially immutable) of all the servers defined in this path item
      **/
     List<Server> getServers();
 
@@ -343,7 +343,7 @@ public interface PathItem extends Constructible, Extensible<PathItem>, Reference
     /**
      * Returns the parameters property from this PathItem instance.
      *
-     * @return a list of parameters that are applicable to all the operations described under this path
+     * @return a copy List (potentially immutable) of parameters that are applicable to all the operations described under this path
      **/
     List<Parameter> getParameters();
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/headers/Header.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/headers/Header.java
@@ -232,7 +232,7 @@ public interface Header extends Constructible, Extensible<Header>, Reference<Hea
     /**
      * Returns the examples property from a Header instance.
      *
-     * @return examples of the media type
+     * @return a copy Map (potentially immutable) of examples of the header
      **/
     Map<String, Example> getExamples();
 
@@ -240,7 +240,7 @@ public interface Header extends Constructible, Extensible<Header>, Reference<Hea
      * Sets the examples property of this Header instance to the given map. Each example should contain a value in the correct format as specified in
      * the parameter encoding. The examples object is mutually exclusive of the example object.
      *
-     * @param examples examples of the media type
+     * @param examples examples of the header
      */
     void setExamples(Map<String, Example> examples);
 
@@ -248,7 +248,7 @@ public interface Header extends Constructible, Extensible<Header>, Reference<Hea
      * Sets the examples property of this Header instance to the given map. Each example should contain a value in the correct format as specified in
      * the parameter encoding. The examples object is mutually exclusive of the example object.
      *
-     * @param examples examples of the media type
+     * @param examples examples of the header
      * @return the current Header instance
      */
     default Header examples(Map<String, Example> examples) {
@@ -257,17 +257,17 @@ public interface Header extends Constructible, Extensible<Header>, Reference<Hea
     }
 
     /**
-     * Adds an example of the media type using the specified key to this Header instance. The example should contain a value in the correct format as
+     * Adds an example of the header using the specified key to this Header instance. The example should contain a value in the correct format as
      * specified in the parameter encoding.
      *
      * @param key string to represent the example
-     * @param example example of the media type
+     * @param example example of the header
      * @return the current Header instance
      */
     Header addExample(String key, Example example);
 
     /**
-     * Removes an example of the media type using the specified key to this Header instance.
+     * Removes an example of the header using the specified key to this Header instance.
      *
      * @param key string to represent the example
      */
@@ -276,7 +276,7 @@ public interface Header extends Constructible, Extensible<Header>, Reference<Hea
     /**
      * Returns the example property from a Header instance.
      *
-     * @return example of the media type
+     * @return example of the header
      **/
     Object getExample();
 
@@ -284,7 +284,7 @@ public interface Header extends Constructible, Extensible<Header>, Reference<Hea
      * Sets this Header's example property to the given object. The example should match the specified schema and encoding properties if present. The
      * examples object is mutually exclusive of the example object.
      *
-     * @param example example of the media type
+     * @param example example of the header
      */
     void setExample(Object example);
 
@@ -292,7 +292,7 @@ public interface Header extends Constructible, Extensible<Header>, Reference<Hea
      * Sets this Header's example property to the given object. The example should match the specified schema and encoding properties if present. The
      * examples object is mutually exclusive of the example object.
      *
-     * @param example example of the media type
+     * @param example example of the header
      * @return the current Header instance
      */
     default Header example(Object example) {

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/links/Link.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/links/Link.java
@@ -146,7 +146,7 @@ public interface Link extends Constructible, Extensible<Link>, Reference<Link> {
      * Returns the parameters property from this instance of Link. The key is the parameter name and the value is a constant or a runtime expression
      * to be passed to the linked operation.
      *
-     * @return a map representing parameters to pass to this link's operation
+     * @return a copy Map (potentially immutable) representing parameters to pass to this link's operation
      **/
     Map<String, Object> getParameters();
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Discriminator.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Discriminator.java
@@ -89,7 +89,7 @@ public interface Discriminator extends Constructible {
     /**
      * Returns the mapping property from a Discriminator instance.
      *
-     * @return a map containing keys and schema names or references
+     * @return a copy Map (potentially immutable) containing keys and schema names or references
      **/
     Map<String, String> getMapping();
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Encoding.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Encoding.java
@@ -97,7 +97,7 @@ public interface Encoding extends Constructible, Extensible<Encoding> {
      * <p>
      * This method returns the headers property from a Encoding instance.
      * </p>
-     * @return Map&lt;String, Header&gt; headers
+     * @return a copy Map (potentially immutable) containing headers
      **/
     Map<String, Header> getHeaders();
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/media/MediaType.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/media/MediaType.java
@@ -62,7 +62,7 @@ public interface MediaType extends Constructible, Extensible<MediaType> {
     /**
      * Returns the collection of examples from a MediaType instance.
      *
-     * @return examples of the media type
+     * @return a copy Map (potentially immutable) of examples of the media type
      **/
     Map<String, Example> getExamples();
 
@@ -134,7 +134,7 @@ public interface MediaType extends Constructible, Extensible<MediaType> {
     /**
      * Returns the encoding property from a MediaType instance.
      *
-     * @return a map between a property name and its encoding information
+     * @return  a copy Map (potentially immutable) between a property name and its encoding information
      **/
     Map<String, Encoding> getEncoding();
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Schema.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Schema.java
@@ -139,7 +139,7 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
     /**
      * Returns the enumerated list of values allowed for objects defined by this Schema.
      *
-     * @return the list of values allowed for objects defined by this Schema
+     * @return a copy List (potentially immutable) of values allowed for objects defined by this Schema
      */
     List<Object> getEnumeration();
 
@@ -512,7 +512,7 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
     /**
      * Returns the required property from this Schema instance.
      *
-     * @return the list of fields required in objects defined by this Schema
+     * @return a copy List (potentially immutable) of fields required in objects defined by this Schema
      **/
     List<String> getRequired();
 
@@ -604,7 +604,7 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
     /**
      * Returns the properties defined in this Schema.
      *
-     * @return a map which associates property names with the schemas that describe their contents
+     * @return a copy Map (potentially immutable) which associates property names with the schemas that describe their contents
      **/
     Map<String, Schema> getProperties();
 
@@ -980,7 +980,7 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
     /**
      * Returns the schemas used by the allOf property.
      *
-     * @return the list of schemas used by the allOf property
+     * @return a copy List (potentially immutable) of schemas used by the allOf property
      **/
     List<Schema> getAllOf();
 
@@ -1020,7 +1020,7 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
     /**
      * Returns the schemas used by the anyOf property.
      *
-     * @return the list of schemas used by the anyOf property
+     * @return a copy List (potentially immutable) of schemas used by the anyOf property
      **/
     List<Schema> getAnyOf();
 
@@ -1060,7 +1060,7 @@ public interface Schema extends Extensible<Schema>, Constructible, Reference<Sch
     /**
      * Returns the schemas used by the oneOf property.
      *
-     * @return the list of schemas used by the oneOf property
+     * @return a copy List (potentially immutable) of schemas used by the oneOf property
      **/
     List<Schema> getOneOf();
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/parameters/Parameter.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/parameters/Parameter.java
@@ -342,7 +342,7 @@ public interface Parameter extends Constructible, Extensible<Parameter>, Referen
     /**
      * Returns the examples property from a Parameter instance.
      *
-     * @return examples of the media type
+     * @return a copy Map (potentially immutable) of examples of the parameter
      **/
     Map<String, Example> getExamples();
 
@@ -350,7 +350,7 @@ public interface Parameter extends Constructible, Extensible<Parameter>, Referen
      * Sets the examples property of a Parameter instance to the given value. Each example should contain a value in the correct format as specified
      * in the parameter encoding. The examples object is mutually exclusive of the example object.
      *
-     * @param examples examples of the media type
+     * @param examples examples of the parameter
      */
     void setExamples(Map<String, Example> examples);
 
@@ -358,7 +358,7 @@ public interface Parameter extends Constructible, Extensible<Parameter>, Referen
      * Sets the examples property of a Parameter instance to the given value. Each example should contain a value in the correct format as specified
      * in the parameter encoding. The examples object is mutually exclusive of the example object.
      *
-     * @param examples examples of the media type
+     * @param examples examples of the parameter
      * @return the current Parameter instance
      */
     default Parameter examples(Map<String, Example> examples) {
@@ -367,17 +367,17 @@ public interface Parameter extends Constructible, Extensible<Parameter>, Referen
     }
 
     /**
-     * Adds an example of the media type using the specified key. The example should contain a value in the correct format as specified in the
+     * Adds an example of the parameter using the specified key. The example should contain a value in the correct format as specified in the
      * parameter encoding.
      *
      * @param key string to represent the example
-     * @param example example of the media type
+     * @param example example of the parameter
      * @return the current Parameter instance
      */
     Parameter addExample(String key, Example example);
 
     /**
-     * Removes an example of the media type using the specified key. The example should contain a value in the correct format as specified in the
+     * Removes an example of the parameter using the specified key. The example should contain a value in the correct format as specified in the
      * parameter encoding.
      *
      * @param key string to represent the example
@@ -387,7 +387,7 @@ public interface Parameter extends Constructible, Extensible<Parameter>, Referen
     /**
      * Returns the example property from a Parameter instance.
      *
-     * @return example of the media type
+     * @return example of the parameter
      **/
     Object getExample();
 
@@ -395,7 +395,7 @@ public interface Parameter extends Constructible, Extensible<Parameter>, Referen
      * Sets the example property of a Parameter instance to the given object. The example should match the specified schema and encoding properties if
      * present. The examples object is mutually exclusive of the example object.
      *
-     * @param example example of the media type
+     * @param example example of the parameter
      */
     void setExample(Object example);
 
@@ -403,7 +403,7 @@ public interface Parameter extends Constructible, Extensible<Parameter>, Referen
      * Sets the example property of a Parameter instance to the given object. The example should match the specified schema and encoding properties if
      * present. The examples object is mutually exclusive of the example object.
      *
-     * @param example example of the media type
+     * @param example example of the parameter
      * @return the current Parameter instance
      */
     default Parameter example(Object example) {

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponse.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/responses/APIResponse.java
@@ -64,7 +64,7 @@ public interface APIResponse extends Constructible, Extensible<APIResponse>, Ref
     /**
      * Returns the map of Headers in this instance of ApiResponse.
      *
-     * @return the headers of this response
+     * @return a copy Map (potentially immutable) of the headers of this response
      **/
 
     Map<String, Header> getHeaders();
@@ -140,9 +140,9 @@ public interface APIResponse extends Constructible, Extensible<APIResponse>, Ref
     }
 
     /**
-     * Returns the operations links that can be followed from tis instance of ApiResponse.
+     * Returns the operations links that can be followed from this instance of ApiResponse.
      *
-     * @return operation links that can be followed from the response
+     * @return a copy Map (potentially immutable) of links that can be followed from the response
      **/
 
     Map<String, Link> getLinks();

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/servers/ServerVariable.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/servers/ServerVariable.java
@@ -34,7 +34,7 @@ public interface ServerVariable extends Constructible, Extensible<ServerVariable
      * <p>
      * This property represents an enumeration of string values to be used if the substitution options are from a limited set
      * </p> 
-     * @return List&lt;String&gt; enumeration
+     * @return a copy List (potentially immutable) of possible values for this variable
      **/
     List<String> getEnumeration();
 

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
@@ -161,6 +161,8 @@ public class ModelConstructionTest {
         assertEquals(c.getCallbacks().size(), 1, "The list is expected to contain one entry.");
         c.removeCallback(callbackKey);
         assertEquals(c.getCallbacks().size(), 0, "The list is expected to be empty.");
+        Callback otherCallbackValue  = createConstructibleInstance(Callback.class);
+        checkMapImmutable(c, Components::getCallbacks, "otherCallback", otherCallbackValue);
         
         final String exampleKey = "myExample";
         final Example exampleValue = createConstructibleInstance(Example.class);
@@ -169,6 +171,8 @@ public class ModelConstructionTest {
         assertEquals(c.getExamples().size(), 1, "The list is expected to contain one entry.");
         c.removeExample(exampleKey);
         assertEquals(c.getExamples().size(), 0, "The list is expected to be empty.");
+        Example otherExampleValue  = createConstructibleInstance(Example.class);
+        checkMapImmutable(c, Components::getExamples, "otherExample", otherExampleValue);
         
         final String headerKey = "myHeader";
         final Header headerValue = createConstructibleInstance(Header.class);
@@ -177,6 +181,8 @@ public class ModelConstructionTest {
         assertEquals(c.getHeaders().size(), 1, "The list is expected to contain one entry.");
         c.removeHeader(headerKey);
         assertEquals(c.getHeaders().size(), 0, "The list is expected to be empty.");
+        Header otherHeaderValue  = createConstructibleInstance(Header.class);
+        checkMapImmutable(c, Components::getHeaders, "otherHeader", otherHeaderValue);
         
         final String linkKey = "myLink";
         final Link linkValue = createConstructibleInstance(Link.class);
@@ -185,6 +191,8 @@ public class ModelConstructionTest {
         assertEquals(c.getLinks().size(), 1, "The list is expected to contain one entry.");
         c.removeLink(linkKey);
         assertEquals(c.getLinks().size(), 0, "The list is expected to be empty.");
+        Link otherLinkValue  = createConstructibleInstance(Link.class);
+        checkMapImmutable(c, Components::getLinks, "otherLink", otherLinkValue);
         
         final String parameterKey = "myParameter";
         final Parameter parameterValue = createConstructibleInstance(Parameter.class);
@@ -193,6 +201,8 @@ public class ModelConstructionTest {
         assertEquals(c.getParameters().size(), 1, "The list is expected to contain one entry.");
         c.removeParameter(parameterKey);
         assertEquals(c.getParameters().size(), 0, "The list is expected to be empty.");
+        Parameter otherParameterValue  = createConstructibleInstance(Parameter.class);
+        checkMapImmutable(c, Components::getParameters, "otherParameter", otherParameterValue);
         
         final String requestBodyKey = "myRequestBody";
         final RequestBody requestBodyValue = createConstructibleInstance(RequestBody.class);
@@ -201,6 +211,8 @@ public class ModelConstructionTest {
         assertEquals(c.getRequestBodies().size(), 1, "The list is expected to contain one entry.");
         c.removeRequestBody(requestBodyKey);
         assertEquals(c.getRequestBodies().size(), 0, "The list is expected to be empty.");
+        RequestBody otherRequestBodyValue  = createConstructibleInstance(RequestBody.class);
+        checkMapImmutable(c, Components::getRequestBodies, "otherRequestBody", otherRequestBodyValue);
         
         final String responseKey = "myResponse";
         final APIResponse responseValue = createConstructibleInstance(APIResponse.class);
@@ -209,6 +221,8 @@ public class ModelConstructionTest {
         assertEquals(c.getResponses().size(), 1, "The list is expected to contain one entry.");
         c.removeResponse(responseKey);
         assertEquals(c.getResponses().size(), 0, "The list is expected to be empty.");
+        APIResponse otherAPIResponseValue  = createConstructibleInstance(APIResponse.class);
+        checkMapImmutable(c, Components::getResponses, "otherAPIResponse", otherAPIResponseValue);
         
         final String schemaKey = "mySchema";
         final Schema schemaValue = createConstructibleInstance(Schema.class);
@@ -217,6 +231,8 @@ public class ModelConstructionTest {
         assertEquals(c.getSchemas().size(), 1, "The list is expected to contain one entry.");
         c.removeSchema(schemaKey);
         assertEquals(c.getSchemas().size(), 0, "The list is expected to be empty.");
+        Schema otherSchemaValue  = createConstructibleInstance(Schema.class);
+        checkMapImmutable(c, Components::getSchemas, "otherSchema", otherSchemaValue);
         
         final String securitySchemeKey = "mySecurityScheme";
         final SecurityScheme securitySchemeValue = createConstructibleInstance(SecurityScheme.class);
@@ -225,6 +241,8 @@ public class ModelConstructionTest {
         assertEquals(c.getSecuritySchemes().size(), 1, "The list is expected to contain one entry.");
         c.removeSecurityScheme(securitySchemeKey);
         assertEquals(c.getSecuritySchemes().size(), 0, "The list is expected to be empty.");
+        SecurityScheme otherSecuritySchemeValue  = createConstructibleInstance(SecurityScheme.class);
+        checkMapImmutable(c, Components::getSecuritySchemes, "otherSecurityScheme", otherSecuritySchemeValue);
     }
     
     @Test
@@ -242,6 +260,8 @@ public class ModelConstructionTest {
         assertEquals(o.getSecurity().size(), 1, "The list is expected to contain one entry.");
         o.removeSecurityRequirement(sr);
         assertEquals(o.getSecurity().size(), 0, "The list is expected to be empty.");
+        SecurityRequirement otherSecurityRequirementValue  = createConstructibleInstance(SecurityRequirement.class);
+        checkListImmutable(o, OpenAPI::getSecurity, otherSecurityRequirementValue);
         
         final Server s = createConstructibleInstance(Server.class);
         checkSameObject(o, o.addServer(s));
@@ -249,6 +269,8 @@ public class ModelConstructionTest {
         assertEquals(o.getServers().size(), 1, "The list is expected to contain one entry.");
         o.removeServer(s);
         assertEquals(o.getServers().size(), 0, "The list is expected to be empty.");
+        Server otherServer  = createConstructibleInstance(Server.class);
+        checkListImmutable(o, OpenAPI::getServers, otherServer);
         
         final Tag t = createConstructibleInstance(Tag.class);
         checkSameObject(o, o.addTag(t));
@@ -256,6 +278,8 @@ public class ModelConstructionTest {
         assertEquals(o.getTags().size(), 1, "The list is expected to contain one entry.");
         o.removeTag(t);
         assertEquals(o.getTags().size(), 0, "The list is expected to be empty.");
+        Tag otherTag  = createConstructibleInstance(Tag.class);
+        checkListImmutable(o, OpenAPI::getTags, otherTag);
     }
     
     @Test
@@ -268,6 +292,8 @@ public class ModelConstructionTest {
         assertEquals(o.getParameters().size(), 1, "The list is expected to contain one entry.");
         o.removeParameter(p);
         assertEquals(o.getParameters().size(), 0, "The list is expected to be empty.");
+        Parameter otherParameter  = createConstructibleInstance(Parameter.class);
+        checkListImmutable(o, Operation::getParameters, otherParameter);
         
         final SecurityRequirement sr = createConstructibleInstance(SecurityRequirement.class);
         checkSameObject(o, o.addSecurityRequirement(sr));
@@ -275,6 +301,8 @@ public class ModelConstructionTest {
         assertEquals(o.getSecurity().size(), 1, "The list is expected to contain one entry.");
         o.removeSecurityRequirement(sr);
         assertEquals(o.getSecurity().size(), 0, "The list is expected to be empty.");
+        SecurityRequirement otherSecurityRequirement  = createConstructibleInstance(SecurityRequirement.class);
+        checkListImmutable(o, Operation::getSecurity, otherSecurityRequirement);
         
         final Server s = createConstructibleInstance(Server.class);
         checkSameObject(o, o.addServer(s));
@@ -282,6 +310,8 @@ public class ModelConstructionTest {
         assertEquals(o.getServers().size(), 1, "The list is expected to contain one entry.");
         o.removeServer(s);
         assertEquals(o.getServers().size(), 0, "The list is expected to be empty.");
+        Server otherServer  = createConstructibleInstance(Server.class);
+        checkListImmutable(o, Operation::getServers, otherServer);
         
         final String tag = new String("myTag");
         checkSameObject(o, o.addTag(tag));
@@ -289,6 +319,8 @@ public class ModelConstructionTest {
         assertEquals(o.getTags().size(), 1, "The list is expected to contain one entry.");
         o.removeTag(tag);
         assertEquals(o.getTags().size(), 0, "The list is expected to be empty.");
+        String otherTag  = new String("otherTag");
+        checkListImmutable(o, Operation::getTags, otherTag);
         
         final String callbackKey = "myCallback";
         final Callback callbackValue = createConstructibleInstance(Callback.class);
@@ -297,6 +329,8 @@ public class ModelConstructionTest {
         assertEquals(o.getCallbacks().size(), 1, "The list is expected to contain one entry.");
         o.removeCallback(callbackKey);
         assertEquals(o.getCallbacks().size(), 0, "The list is expected to be empty.");
+        Callback otherCallback  = createConstructibleInstance(Callback.class);
+        checkMapImmutable(o, Operation::getCallbacks, "otherCallback", otherCallback);
     }
     
     @Test
@@ -309,6 +343,8 @@ public class ModelConstructionTest {
         assertEquals(pi.getParameters().size(), 1, "The list is expected to contain one entry.");
         pi.removeParameter(p);
         assertEquals(pi.getParameters().size(), 0, "The list is expected to be empty.");
+        Parameter otherParameter  = createConstructibleInstance(Parameter.class);
+        checkListImmutable(pi, PathItem::getParameters, otherParameter);
         
         final Server s = createConstructibleInstance(Server.class);
         checkSameObject(pi, pi.addServer(s));
@@ -316,6 +352,8 @@ public class ModelConstructionTest {
         assertEquals(pi.getServers().size(), 1, "The list is expected to contain one entry.");
         pi.removeServer(s);
         assertEquals(pi.getServers().size(), 0, "The list is expected to be empty.");
+        Server otherServer  = createConstructibleInstance(Server.class);
+        checkListImmutable(pi, PathItem::getServers, otherServer);
         
         final Operation o1 = createConstructibleInstance(Operation.class);
         checkSameObject(pi, pi.GET(o1));
@@ -447,6 +485,8 @@ public class ModelConstructionTest {
         assertEquals(h.getExamples().size(), 1, "The list is expected to contain one entry.");
         h.removeExample(exampleKey);
         assertEquals(h.getExamples().size(), 0, "The list is expected to be empty.");
+        Example otherExampleValue = createConstructibleInstance(Example.class);
+        checkMapImmutable(h, Header::getExamples, "otherExample", otherExampleValue);
     }
     
     @Test
@@ -475,6 +515,8 @@ public class ModelConstructionTest {
         assertEquals(l.getParameters().size(), 1, "The list is expected to contain one entry.");
         l.removeParameter(parameterKey);
         assertEquals(l.getParameters().size(), 0, "The list is expected to be empty.");
+        Object otherExampleValue = new Object();
+        checkMapImmutable(l, Link::getParameters, "otherParameter", otherExampleValue);
     }
     
     @Test
@@ -524,6 +566,8 @@ public class ModelConstructionTest {
         assertEquals(d.getMapping().size(), 1, "The list is expected to contain one entry.");
         d.removeMapping(key);
         assertEquals(d.getMapping().size(), 0, "The list is expected to be empty.");
+        final String otherValue = new String("otherValue");
+        checkMapImmutable(d, Discriminator::getMapping, "otherValue", otherValue);
     }
     
     @Test
@@ -537,6 +581,8 @@ public class ModelConstructionTest {
         assertEquals(e.getHeaders().size(), 1, "The list is expected to contain one entry.");
         e.removeHeader(headerKey);
         assertEquals(e.getHeaders().size(), 0, "The list is expected to be empty.");
+        final Header otherHeaderValue = createConstructibleInstance(Header.class);
+        checkMapImmutable(e, Encoding::getHeaders, "otherHeader", otherHeaderValue);
     }
     
     @Test
@@ -550,6 +596,8 @@ public class ModelConstructionTest {
         assertEquals(mt.getEncoding().size(), 1, "The list is expected to contain one entry.");
         mt.removeEncoding(encodingKey);
         assertEquals(mt.getEncoding().size(), 0, "The list is expected to be empty.");
+        Encoding otherEncodingValue = createConstructibleInstance(Encoding.class);
+        checkMapImmutable(mt, MediaType::getEncoding, "otherEncoding", otherEncodingValue);
         
         final String exampleKey = "myExample";
         final Example exampleValue = createConstructibleInstance(Example.class);
@@ -558,6 +606,8 @@ public class ModelConstructionTest {
         assertEquals(mt.getExamples().size(), 1, "The list is expected to contain one entry.");
         mt.removeExample(exampleKey);
         assertEquals(mt.getExamples().size(), 0, "The list is expected to be empty.");
+        Example otherExampleValue = createConstructibleInstance(Example.class);
+        checkMapImmutable(mt, MediaType::getExamples, "otherExample", otherExampleValue);
     }
     
     @Test
@@ -584,6 +634,8 @@ public class ModelConstructionTest {
         assertEquals(s.getAllOf().size(), 1, "The list is expected to contain one entry.");
         s.removeAllOf(allOf);
         assertEquals(s.getAllOf().size(), 0, "The list is expected to be empty.");
+        final Schema otherAllOfValue = createConstructibleInstance(Schema.class);
+        checkListImmutable(s, Schema::getAllOf, otherAllOfValue);
         
         final Schema anyOf = createConstructibleInstance(Schema.class);
         checkSameObject(s, s.addAnyOf(anyOf));
@@ -591,6 +643,8 @@ public class ModelConstructionTest {
         assertEquals(s.getAnyOf().size(), 1, "The list is expected to contain one entry.");
         s.removeAnyOf(anyOf);
         assertEquals(s.getAnyOf().size(), 0, "The list is expected to be empty.");
+        final Schema otherAnyOfValue = createConstructibleInstance(Schema.class);
+        checkListImmutable(s, Schema::getAnyOf, otherAnyOfValue);
         
         final String enumeration = new String("enumValue");
         checkSameObject(s, s.addEnumeration(enumeration));
@@ -598,6 +652,8 @@ public class ModelConstructionTest {
         assertEquals(s.getEnumeration().size(), 1, "The list is expected to contain one entry.");
         s.removeEnumeration(enumeration);
         assertEquals(s.getEnumeration().size(), 0, "The list is expected to be empty.");
+        final String otherEnumerationValue = new String("otherValue");
+        checkListImmutable(s, Schema::getEnumeration , otherEnumerationValue);
         
         final Schema oneOf = createConstructibleInstance(Schema.class);
         checkSameObject(s, s.addOneOf(oneOf));
@@ -605,6 +661,8 @@ public class ModelConstructionTest {
         assertEquals(s.getOneOf().size(), 1, "The list is expected to contain one entry.");
         s.removeOneOf(oneOf);
         assertEquals(s.getOneOf().size(), 0, "The list is expected to be empty.");
+        final Schema otherOneOfValue = createConstructibleInstance(Schema.class);
+        checkListImmutable(s, Schema::getOneOf, otherOneOfValue);
         
         final String propertySchemaKey = "myPropertySchemaKey";
         final Schema propertySchemaValue = createConstructibleInstance(Schema.class);
@@ -613,6 +671,8 @@ public class ModelConstructionTest {
         assertEquals(s.getProperties().size(), 1, "The list is expected to contain one entry.");
         s.removeProperty(propertySchemaKey);
         assertEquals(s.getProperties().size(), 0, "The list is expected to be empty.");
+        final Schema otherPropertyValue = createConstructibleInstance(Schema.class);
+        checkMapImmutable(s, Schema::getProperties, "otherPropertyKey", otherPropertyValue);
         
         final String required = new String("required");
         checkSameObject(s, s.addRequired(required));
@@ -620,6 +680,8 @@ public class ModelConstructionTest {
         assertEquals(s.getRequired().size(), 1, "The list is expected to contain one entry.");
         s.removeRequired(required);
         assertEquals(s.getRequired().size(), 0, "The list is expected to be empty.");
+        final String otherRequiredValue = new String("otherRequired");
+        checkListImmutable(s, Schema::getEnumeration, otherRequiredValue);
     }
     
     @Test
@@ -638,6 +700,8 @@ public class ModelConstructionTest {
         assertEquals(p.getExamples().size(), 1, "The list is expected to contain one entry.");
         p.removeExample(exampleKey);
         assertEquals(p.getExamples().size(), 0, "The list is expected to be empty.");
+        Example otherExampleValue = createConstructibleInstance(Example.class);
+        checkMapImmutable(p, Parameter::getExamples, "otherExample", otherExampleValue);
     }
     
     @Test
@@ -656,6 +720,8 @@ public class ModelConstructionTest {
         assertEquals(response.getHeaders().size(), 1, "The list is expected to contain one entry.");
         response.removeHeader(headerKey);
         assertEquals(response.getHeaders().size(), 0, "The list is expected to be empty.");
+        Header otherHeaderValue  = createConstructibleInstance(Header.class);
+        checkMapImmutable(response, APIResponse::getHeaders, "otherHeader", otherHeaderValue);
         
         final String linkKey = "myLinkKey";
         final Link linkValue = createConstructibleInstance(Link.class);
@@ -664,6 +730,8 @@ public class ModelConstructionTest {
         assertEquals(response.getLinks().size(), 1, "The list is expected to contain one entry.");
         response.removeLink(linkKey);
         assertEquals(response.getLinks().size(), 0, "The list is expected to be empty.");
+        Link otherLinkValue  = createConstructibleInstance(Link.class);
+        checkMapImmutable(response, APIResponse::getLinks, "otherLink", otherLinkValue);
     }
     
     @Test
@@ -827,6 +895,8 @@ public class ModelConstructionTest {
         assertEquals(sv.getEnumeration().size(), 1, "The list is expected to contain one entry.");
         sv.removeEnumeration(enumeration);
         assertEquals(sv.getEnumeration().size(), 0, "The list is expected to be empty.");
+        final String otherEnumerationValue = new String("otherValue");
+        checkListImmutable(sv, ServerVariable::getEnumeration , otherEnumerationValue);
     }
     
     @Test
@@ -928,6 +998,8 @@ public class ModelConstructionTest {
         final Map<String, Object> map3 = e.getExtensions();
         assertEquals(map3.size(), 1, "The extensions map is expected to contain one entry.");
         assertEquals(map3, newOtherMap, "The return value of getExtensions() is expected to be the same value that was set.");
+        
+        checkMapImmutable(e, Extensible::getExtensions, "x-other", new Object());
     }
     
     private void processReference(Reference<?> r) {
@@ -1168,6 +1240,23 @@ public class ModelConstructionTest {
     private <T> void checkListEntry(List<T> list, T value) {
         assertNotNull(list, "The list must not be null.");
         assertTrue(list.stream().anyMatch((v) -> v == value), "The list is expected to contain the value: " + value);
+    }
+    
+    private <O, V> void checkListImmutable(O container, Function<O, List<V>> listGetter, V otherValue) {
+        List<V> list = listGetter.apply(container);
+        assertNotNull(list, "The list must not be null.");
+        assertFalse(list.contains(otherValue), "The list is expected to not contain the value: " + otherValue);
+        int originalSize = list.size();
+        try {
+            list.add(otherValue);
+        }
+        catch (Exception e) {
+            //It is allowed to throw an exception
+        }
+        List<V>  map2 = listGetter.apply(container);
+        assertNotNull(map2, "The list must not be null.");
+        assertFalse(map2.contains(otherValue), "The list is expected to not contain the key: " + otherValue);
+        assertEquals(map2.size(), originalSize, "The list is expected to have a size of " + originalSize);
     }
     
     private <T> void checkSameObject(T expected, T actual) {


### PR DESCRIPTION
For all maps and list getter (see list bellow) this PR for `2.0` version adds:

* A Javadoc comment
* A TCK Test

To ensure that the returned list/map is a copy of the original one.

---
**For MAPS:**

Interface `org.eclipse.microprofile.openapi.models.Components` :
* `getSchemas()`
* `getResponses()`
* `getParameters()`
* `getExamples()`
* `getRequestBodies()`
* `getHeaders()`
* `getSecuritySchemes()`
* `getLinks()`
* `getCallbacks()`


Interface `org.eclipse.microprofile.openapi.models.Operation` :
* `getCallbacks()`


Interface `org.eclipse.microprofile.openapi.models.headers.Header` :
* `getExamples()`


Interface `org.eclipse.microprofile.openapi.models.links.Link` :
* `getParameters()`


Interface `org.eclipse.microprofile.openapi.models.media.Discriminator` :
* `getMapping()`


Interface `org.eclipse.microprofile.openapi.models.media.Encoding` :
* `getHeaders()`


Interface `org.eclipse.microprofile.openapi.models.media.MediaType` :
* `getExamples()`
* `getEncoding()`


Interface `org.eclipse.microprofile.openapi.models.media.Schema` :
* `getProperties()`


Interface `org.eclipse.microprofile.openapi.models.parameters.Parameter` :
* `getExamples()`


Interface `org.eclipse.microprofile.openapi.models.responses.APIResponse` :
* `getHeaders()`
* `getLinks()`


---
**For LISTS:**

Interface `org.eclipse.microprofile.openapi.models.OpenAPI` :
* `getServers()`
* `getSecurity()`
* `getTags()`


Interface `org.eclipse.microprofile.openapi.models.Operation` :
* `getTags()`
* `getParameters()`
* `getSecurity()`
* `getServers()`


Interface `org.eclipse.microprofile.openapi.models.PathItem` :
* `getServers()`
* `getParameters()`


Interface `org.eclipse.microprofile.openapi.models.media.Schema` :
* `getEnumeration()`
* `getRequired()`
* `getAllOf()`
* `getAnyOf()`
* `getOneOf()`


Interface `org.eclipse.microprofile.openapi.models.servers.ServerVariable` :
* `getEnumeration()`
