### PR TITLE
Fix checkstyle error

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
@@ -966,7 +966,7 @@ public class ModelConstructionTest {
         s.removeRequired(required);
         assertEquals(s.getRequired().size(), 0, "The list is expected to be empty.");
         
-        final String required2 = new String("required2");;
+        final String required2 = new String("required2");
         s.setRequired(Collections.singletonList(required2));
         assertEquals(s.getRequired().size(), 1, "The list is expected to contain one entry.");
         checkListEntry(s.getRequired(), required2);


### PR DESCRIPTION
This PR solves a small checkstyle error introduced with #293 on branch `2.0`:

```
[INFO] --- maven-checkstyle-plugin:2.17:check (verify-style) @ microprofile-openapi-tck ---
[INFO] Starting audit...
/___/microprofile-open-api/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java:969:58: error: Empty statement.
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:2.17:check (verify-style) on project microprofile-openapi-tck: Failed during checkstyle execution: There is 1 error reported by Checkstyle 6.11.2 with /Users/umac/JBR/Git/microprofile-open-api/tck/target/checkstyle-rules.xml ruleset. -> [Help 1]
```