### PR TITLE
Better testing of PATCH in the TCK.  Fixes #291

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 .classpath
 .project
 .factorypath
+.externalToolBuilders/
 bin/
 target/

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <maven-compiler-plugin.version>2.3.2</maven-compiler-plugin.version>
         <arquillian.version>1.1.13.Final</arquillian.version>
         <testng.version>6.10</testng.version>
-        <jaxrs.version>2.0</jaxrs.version>
+        <jaxrs.version>2.1</jaxrs.version>
         <rest-assured.version>3.0.6</rest-assured.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
         <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
@@ -282,6 +282,7 @@
                         <exclude>**/*.iml</exclude>
                         <exclude>**/*.idea</exclude>
                         <exclude>**/*.ipr</exclude>
+                        <exclude>**/.externalToolBuilders/*</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/UserResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/UserResource.java
@@ -15,6 +15,7 @@ package org.eclipse.microprofile.openapi.apps.airlines.resources;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -42,6 +43,7 @@ import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirementsSet;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
 import org.eclipse.microprofile.openapi.annotations.servers.Server;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -66,12 +68,13 @@ public class UserResource {
     private static UserData userData = new UserData();
 
     public UserData getUserData() {
-        return this.userData;
+        return UserResource.userData;
     }
 
     public void setUserData(UserData userData) {
-        this.userData = userData;
+        UserResource.userData = userData;
     }
+    
     @POST
     @Tags(refs={"user","create"})
     @APIResponses(value={
@@ -344,6 +347,49 @@ public class UserResource {
                 return Response.ok().entity("").build();
             }
 
+    @PATCH
+    @Path("/{username}")
+    @APIResponse(
+            responseCode = "200",
+            description = "Password was changed successfully"
+        )
+    @Operation(
+        summary = "Change user password",
+        description = "This changes the password for the logged in user.",
+        operationId = "changePassword"
+    )
+    @SecurityRequirementsSet(
+        value = {
+            @SecurityRequirement(
+                name = "userApiKey"
+            ),
+            @SecurityRequirement(
+                name = "userBearerHttp"
+            )
+        }
+    )
+    public void changePassword(
+        @Parameter(
+            name = "username",
+            description = "name that need to be deleted",
+            schema = @Schema(type = SchemaType.STRING),
+            required = true)
+        @PathParam("username") String username,
+        @Parameter(
+            name = "currentPassword",
+            description = "the user's current password",
+            schema = @Schema(type = SchemaType.STRING),
+            required = true)
+        @QueryParam("currentPassword") String currentPassword,
+        @Parameter(
+            name = "newPassword",
+            description = "the user's desired new password",
+            schema = @Schema(type = SchemaType.STRING),
+            required = true)
+        @QueryParam("newPassword") String newPassword) {
+            // don't do anything - this is just a TCK test
+    }
+    
       @DELETE
       @Path("/{username}")
       @Tag(ref="user")

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/resource/UserResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/resource/UserResource.java
@@ -13,35 +13,34 @@
 
 package org.eclipse.microprofile.openapi.apps.petstore.resource;
 
-import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
-import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
-import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
-import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeIn;
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
-import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
-import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
-import org.eclipse.microprofile.openapi.annotations.security.SecuritySchemes;
-import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
-import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirements;
-import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirementsSet;
-
-import org.eclipse.microprofile.openapi.apps.petstore.data.UserData;
-import org.eclipse.microprofile.openapi.apps.petstore.model.User;
-import org.eclipse.microprofile.openapi.apps.petstore.exception.ApiException;
-import org.eclipse.microprofile.openapi.apps.petstore.exception.NotFoundException;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.GET;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeIn;
+import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirements;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirementsSet;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
+import org.eclipse.microprofile.openapi.annotations.security.SecuritySchemes;
+import org.eclipse.microprofile.openapi.apps.petstore.data.UserData;
+import org.eclipse.microprofile.openapi.apps.petstore.exception.ApiException;
+import org.eclipse.microprofile.openapi.apps.petstore.exception.NotFoundException;
+import org.eclipse.microprofile.openapi.apps.petstore.model.User;
 
 @Path("/user")
 @Schema(name = "/user")

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
@@ -263,6 +263,11 @@ public class AirlinesAppTest extends AppTestBase {
 
         vr.body("paths.'/user/logout'.get.summary", equalTo("Logs out current logged in user session"));
         vr.body("paths.'/user/logout'.get.operationId", equalTo("logOutUser"));
+
+        vr.body("paths.'/user/{username}'.patch.summary", equalTo("Change user password"));
+        vr.body("paths.'/user/{username}'.patch.description", equalTo("This changes the password for the logged in user."));
+        vr.body("paths.'/user/{username}'.patch.operationId", equalTo("changePassword"));
+        vr.body("paths.'/user/{username}'.patch.parameters", hasSize(3));
     }
 
     @RunAsClient

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/StaticDocumentTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/StaticDocumentTest.java
@@ -96,5 +96,35 @@ public class StaticDocumentTest extends AppTestBase {
         vr.body(inventoryPathPost + ".responses.'201'.description", equalTo("item created"));
         vr.body(inventoryPathPost + ".responses.'400'.description", equalTo("invalid input, object invalid"));
         vr.body(inventoryPathPost + ".responses.'409'.description", equalTo("an existing item already exists"));
+
+        final String inventoryPathPut = "paths.'/inventory'.put";
+        vr.body(inventoryPathPut + ".summary", equalTo("put operation"));
+        vr.body(inventoryPathPut + ".operationId", equalTo("putInventory"));
+        vr.body(inventoryPathPut + ".description", equalTo("tests the put operation"));
+
+        final String inventoryPathDelete = "paths.'/inventory'.delete";
+        vr.body(inventoryPathDelete + ".summary", equalTo("delete operation"));
+        vr.body(inventoryPathDelete + ".operationId", equalTo("deleteInventory"));
+        vr.body(inventoryPathDelete + ".description", equalTo("tests the delete operation"));
+
+        final String inventoryPathOptions = "paths.'/inventory'.options";
+        vr.body(inventoryPathOptions + ".summary", equalTo("options operation"));
+        vr.body(inventoryPathOptions + ".operationId", equalTo("optionsInventory"));
+        vr.body(inventoryPathOptions + ".description", equalTo("tests the options operation"));
+
+        final String inventoryPathHead = "paths.'/inventory'.head";
+        vr.body(inventoryPathHead + ".summary", equalTo("head operation"));
+        vr.body(inventoryPathHead + ".operationId", equalTo("headInventory"));
+        vr.body(inventoryPathHead + ".description", equalTo("tests the head operation"));
+
+        final String inventoryPathPatch = "paths.'/inventory'.patch";
+        vr.body(inventoryPathPatch + ".summary", equalTo("patch operation"));
+        vr.body(inventoryPathPatch + ".operationId", equalTo("patchInventory"));
+        vr.body(inventoryPathPatch + ".description", equalTo("tests the patch operation"));
+
+        final String inventoryPathTrace = "paths.'/inventory'.trace";
+        vr.body(inventoryPathTrace + ".summary", equalTo("trace operation"));
+        vr.body(inventoryPathTrace + ".operationId", equalTo("traceInventory"));
+        vr.body(inventoryPathTrace + ".description", equalTo("tests the trace operation"));
     }
 }

--- a/tck/src/main/resources/simpleapi.yaml
+++ b/tck/src/main/resources/simpleapi.yaml
@@ -78,6 +78,48 @@ paths:
             schema:
               $ref: '#/components/schemas/InventoryItem'
         description: Inventory item to add
+    put:
+      summary: put operation
+      operationId: putInventory
+      description: tests the put operation
+      responses:
+        '200':
+          description: put operation tested
+    delete:
+      summary: delete operation
+      operationId: deleteInventory
+      description: tests the delete operation
+      responses:
+        '200':
+          description: delete operation tested
+    options:
+      summary: options operation
+      operationId: optionsInventory
+      description: tests the options operation
+      responses:
+        '200':
+          description: options operation tested
+    head:
+      summary: head operation
+      operationId: headInventory
+      description: tests the head operation
+      responses:
+        '200':
+          description: head operation tested
+    patch:
+      summary: patch operation
+      operationId: patchInventory
+      description: tests the patch operation
+      responses:
+        '200':
+          description: patch operation tested
+    trace:
+      summary: trace operation
+      operationId: traceInventory
+      description: tests the trace operation
+      responses:
+        '200':
+          description: trace operation tested
 components:
   schemas:
     InventoryItem:


### PR DESCRIPTION
Apologies for the import re-org noise in this PR.  Also note that the addition of `externalToolBuilders` is for Eclipse - when I re-imported the mp-oai project it installed a Checkstyle plugin.  That worked but it didn't obey the actual ruleset defined in the `pom.xml`.  So I disabled the plugin, resulting in a local `externalToolBuilders` folder being created.  So I'm just excluding it in the .gitignore and in the rat config.

Signed-off-by: Eric Wittmann <eric.wittmann@gmail.com>