### PR TITLE
Introduced TCK test base class: OASConfigScanClassBase

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassBase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassBase.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.openapi.tck;
+
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.testng.annotations.Test;
+
+import io.restassured.response.ValidatableResponse;
+
+/**
+ * Base class for config scan classes.
+ */
+public abstract class OASConfigScanClassBase extends AppTestBase {
+    private ValidatableResponse vr;
+    
+    @RunAsClient
+    @Test(dataProvider = "formatProvider")
+    public void testScanClass(String type) throws InterruptedException {
+        vr = callEndpoint(type);
+        vr.body("openapi", startsWith("3.0."));
+        vr.body("paths", aMapWithSize(5));
+        vr.body("paths", hasKey("/reviews"));
+        vr.body("paths", hasKey("/reviews/{id}"));
+        vr.body("paths", hasKey("/reviews/users/{user}"));
+        vr.body("paths", hasKey("/reviews/airlines/{airline}"));
+        vr.body("paths", hasKey("/reviews/{user}/{airlines}"));
+        
+        vr.body("paths.'/reviews'", aMapWithSize(2));
+        vr.body("paths.'/reviews/{id}'", aMapWithSize(2)); 
+        vr.body("paths.'/reviews/users/{user}'", aMapWithSize(1));
+        vr.body("paths.'/reviews/airlines/{airline}'", aMapWithSize(1)); 
+        vr.body("paths.'/reviews/{user}/{airlines}'", aMapWithSize(1)); 
+        
+        
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassTest.java
@@ -16,20 +16,11 @@
 
 package org.eclipse.microprofile.openapi.tck;
 
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.startsWith;
-import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
-
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.annotations.Test;
 
-import io.restassured.response.ValidatableResponse;
-
-public class OASConfigScanClassTest extends AppTestBase {
-    private ValidatableResponse vr;
+public class OASConfigScanClassTest extends OASConfigScanClassBase {
     
     @Deployment(name = "airlines")
     public static WebArchive createDeployment() {
@@ -37,25 +28,5 @@ public class OASConfigScanClassTest extends AppTestBase {
                 .addPackages(true, "org.eclipse.microprofile.openapi.apps.airlines")
                 .addAsManifestResource("class-microprofile-config.properties", "microprofile-config.properties");
     }
-    
-    @RunAsClient
-    @Test(dataProvider = "formatProvider")
-    public void testScanClass(String type) throws InterruptedException {
-        vr = callEndpoint(type);
-        vr.body("openapi", startsWith("3.0."));
-        vr.body("paths", aMapWithSize(5));
-        vr.body("paths", hasKey("/reviews"));
-        vr.body("paths", hasKey("/reviews/{id}"));
-        vr.body("paths", hasKey("/reviews/users/{user}"));
-        vr.body("paths", hasKey("/reviews/airlines/{airline}"));
-        vr.body("paths", hasKey("/reviews/{user}/{airlines}"));
-        
-        vr.body("paths.'/reviews'", aMapWithSize(2));
-        vr.body("paths.'/reviews/{id}'", aMapWithSize(2)); 
-        vr.body("paths.'/reviews/users/{user}'", aMapWithSize(1));
-        vr.body("paths.'/reviews/airlines/{airline}'", aMapWithSize(1)); 
-        vr.body("paths.'/reviews/{user}/{airlines}'", aMapWithSize(1)); 
-        
-        
-    }
+
 }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigWebInfTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigWebInfTest.java
@@ -20,9 +20,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
-public class OASConfigWebInfTest extends OASConfigScanClassTest {
+public class OASConfigWebInfTest extends OASConfigScanClassBase {
 
-    @Deployment(name = "airlinesWebInf", order = 2)
+    @Deployment(name = "airlinesWebInf")
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "airlinesWebInf.war")
                 .addPackages(true, "org.eclipse.microprofile.openapi.apps.airlines")


### PR DESCRIPTION
This base class is for OASConfigScanClassTest and OASConfigWebInfTest to avoid duplicate @Deployment annotations in a test hierarchy.  For why this is a potential problem, see:  https://github.com/thorntail/thorntail/pull/1224

Signed-off-by: Eric Wittmann <eric.wittmann@gmail.com>