### PR TITLE
Fix javadoc

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponse.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponse.java
@@ -39,7 +39,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
  * 
  * <pre>
  * &#64;ApiResponse(responseCode="200", description="Calculate load size", content=
- *     [ &#64;Content(mediaType="application/json", Schema=&#64;Schema(type="integer")) ] )
+ *     { &#64;Content(mediaType="application/json", Schema=&#64;Schema(type="integer")) } )
  * &#64;GET
  * public getLuggageWeight(Flight id) {
  *     return getBagWeight(id) + getCargoWeight(id);


### PR DESCRIPTION
An array inside an annotation is denoted by `{ }` instead of `[ ]`