### PR TITLE
Deprecate Scope Object in 1.x

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/OASFactory.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/OASFactory.java
@@ -310,7 +310,9 @@ public final class OASFactory {
      * This method creates a new {@link org.eclipse.microprofile.openapi.models.security.Scopes} instance.
      *
      * @return a new Scopes instance
+     * @deprecated since 1.1 use <code>Map&lt;String, String&gt;</code> for scopes instead
      */
+    @Deprecated
     public static Scopes createScopes() {
         return createObject(Scopes.class);
     }

--- a/api/src/main/java/org/eclipse/microprofile/openapi/OASFactory.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/OASFactory.java
@@ -310,7 +310,7 @@ public final class OASFactory {
      * This method creates a new {@link org.eclipse.microprofile.openapi.models.security.Scopes} instance.
      *
      * @return a new Scopes instance
-     * @deprecated since 1.1 use <code>Map&lt;String, String&gt;</code> for scopes instead
+     * @deprecated since 1.2 use <code>Map&lt;String, String&gt;</code> for scopes instead
      */
     @Deprecated
     public static Scopes createScopes() {

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/security/OAuthFlow.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/security/OAuthFlow.java
@@ -186,7 +186,7 @@ public interface OAuthFlow extends Constructible, Extensible<OAuthFlow> {
      * This method sets the scopes property of OAuthFlow instance to the given argument.
      * </p>
      * @param scopes the available scopes for the OAuth2 security scheme
-     * @deprecated since 1.1 use {@link #setScopes(Map)} instead
+     * @deprecated since 1.2 use {@link #setScopes(Map)} instead
      */
     @Deprecated
     void setScopes(Scopes scopes);
@@ -201,7 +201,7 @@ public interface OAuthFlow extends Constructible, Extensible<OAuthFlow> {
      * </p>
      * @param scopes the available scopes for the OAuth2 security scheme
      * @return OAuthFlow instance with the set scopes property
-     * @deprecated since 1.1, use {@link #scopes(Map)} instead
+     * @deprecated since 1.2, use {@link #scopes(Map)} instead
      */
     @Deprecated
     default OAuthFlow scopes(Scopes scopes) {

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/security/OAuthFlow.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/security/OAuthFlow.java
@@ -17,6 +17,8 @@
 
 package org.eclipse.microprofile.openapi.models.security;
 
+import java.util.Map;
+
 import org.eclipse.microprofile.openapi.models.Constructible;
 import org.eclipse.microprofile.openapi.models.Extensible;
 
@@ -143,7 +145,7 @@ public interface OAuthFlow extends Constructible, Extensible<OAuthFlow> {
      * <p>
      * This method returns the scopes property from OAuthFlow instance.
      * </p> 
-     * @return Scopes scopes
+     * @return Scopes scopes (in the future this method will instead return a <code>Map&lt;String, String&gt;</code>).
      **/
     Scopes getScopes();
 
@@ -157,7 +159,7 @@ public interface OAuthFlow extends Constructible, Extensible<OAuthFlow> {
      * </p>
      * @param scopes the available scopes for the OAuth2 security scheme
      */
-    void setScopes(Scopes scopes);
+    void setScopes(Map<String, String> scopes);
 
     /**
      * The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. This is a REQUIRED property.
@@ -170,6 +172,38 @@ public interface OAuthFlow extends Constructible, Extensible<OAuthFlow> {
      * @param scopes the available scopes for the OAuth2 security scheme
      * @return OAuthFlow instance with the set scopes property
      */
+    default OAuthFlow scopes(Map<String, String> scopes) {
+        setScopes(scopes);
+        return this;
+    }
+
+    /**
+     * The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. This is a REQUIRED property.
+     * <p>
+     * Applies to oauth2.
+     * </p>
+     * <p>
+     * This method sets the scopes property of OAuthFlow instance to the given argument.
+     * </p>
+     * @param scopes the available scopes for the OAuth2 security scheme
+     * @deprecated since 1.1 use {@link #setScopes(Map)} instead
+     */
+    @Deprecated
+    void setScopes(Scopes scopes);
+
+    /**
+     * The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. This is a REQUIRED property.
+     * <p>
+     * Applies to oauth2.
+     * </p>
+     * <p>
+     * This method sets the scopes property of OAuthFlow instance to the given argument and returns the modified instance.
+     * </p>
+     * @param scopes the available scopes for the OAuth2 security scheme
+     * @return OAuthFlow instance with the set scopes property
+     * @deprecated since 1.1, use {@link #scopes(Map)} instead
+     */
+    @Deprecated
     default OAuthFlow scopes(Scopes scopes) {
         setScopes(scopes);
         return this;

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/security/Scopes.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/security/Scopes.java
@@ -26,6 +26,8 @@ import org.eclipse.microprofile.openapi.models.Extensible;
  * Scopes is a property of OAuth Flow Object.
  * 
  * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#oauthFlowObject">OAuthFlow Object</a>
+ * @deprecated a future version will remove this and replace it with a <code>Map&lt;String, String&gt;</code>, because it does not
+ * need to be extensibles
  **/
 
 public interface Scopes extends Constructible, Extensible<Scopes>, Map<String, String> {

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/security/Scopes.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/security/Scopes.java
@@ -29,7 +29,7 @@ import org.eclipse.microprofile.openapi.models.Extensible;
  * @deprecated a future version will remove this and replace it with a <code>Map&lt;String, String&gt;</code>, because it does not
  * need to be extensibles
  **/
-
+@Deprecated
 public interface Scopes extends Constructible, Extensible<Scopes>, Map<String, String> {
 
     /**

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
@@ -783,7 +783,17 @@ public class ModelConstructionTest extends Arquillian {
     
     @Test
     public void oAuthFlowTest() {
-        processConstructible(OAuthFlow.class);
+        final OAuthFlow o = processConstructible(OAuthFlow.class);
+        final String key = "myKey";
+        final String value = new String("myValue");
+        o.setScopes(Collections.singletonMap(key, value));
+        Map<String,String> scopes = o.getScopes().getScopes();
+        assertEquals(scopes.size(), 1, "The list is expected to contain one entry.");
+        assertTrue(scopes.containsKey("myKey"), "The map is expected to contain a 'myKey' entry.");
+        assertEquals(scopes.get(key), value, "The value corresponding to the 'myKey' is wrong.");
+        
+        o.setScopes((Map<String, String>) null);
+        assertNull(o.getScopes(), "The value is expected to be null.");
     }
     
     @Test
@@ -791,6 +801,7 @@ public class ModelConstructionTest extends Arquillian {
         processConstructible(OAuthFlows.class);
     }
     
+    @Deprecated
     @Test
     public void scopesTest() {
         final Scopes s = processConstructible(Scopes.class);


### PR DESCRIPTION
This PR is for issue #345 
Deprecated the `Scope` object and use simple maps to represent scopes in `OAuthFlow`