### PR TITLE
Removed parameter target in Parameters annotation

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/Parameters.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/Parameters.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  *      Object</a>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.PARAMETER, ElementType.METHOD })
+@Target({ ElementType.METHOD })
 @Inherited
 public @interface Parameters {
     /**


### PR DESCRIPTION
This PR fixes issue #340 
With the parameter target removed, `@Parameters` now only have the method target.