### PR TITLE
TCK format test updates

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AppTestBase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AppTestBase.java
@@ -25,10 +25,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.microprofile.openapi.tck.utils.YamlToJsonFilter;
 import org.jboss.arquillian.testng.Arquillian;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.DataProvider;
 
 import io.restassured.RestAssured;
+import io.restassured.filter.Filter;
 import io.restassured.http.ContentType;
 import io.restassured.parsing.Parser;
 import io.restassured.response.ValidatableResponse;
@@ -42,6 +42,8 @@ public abstract class AppTestBase extends Arquillian {
     private static String serverUrl;
     private static String username;
     private static String password;
+
+    protected static final Filter yamlFilter = new YamlToJsonFilter();
 
     @BeforeClass
     public static void configureRestAssured() throws MalformedURLException {
@@ -75,12 +77,6 @@ public abstract class AppTestBase extends Arquillian {
         }
     }
 
-    @BeforeSuite
-    public static void beforeSuite() {
-        // Register a filter that performs YAML to JSON conversion
-        RestAssured.filters(new YamlToJsonFilter());
-    }
-
     public ValidatableResponse callEndpoint(String type) {
         ValidatableResponse vr;
         if ("JSON".equals(type)) {
@@ -88,13 +84,13 @@ public abstract class AppTestBase extends Arquillian {
         }
         else {
             // It seems there is no standard for YAML
-            vr = given().accept(ContentType.ANY).when().get("/openapi").then().statusCode(200);
+            vr = given().filter(yamlFilter).accept(ContentType.ANY).when().get("/openapi").then().statusCode(200);
         }
         return vr;
     }
 
     @DataProvider(name = "formatProvider")
-    public Object[][] provide() throws Exception {
+    public Object[][] provide() {
         return new Object[][] { { "JSON" }, { "YAML" } };
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/PetStoreAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/PetStoreAppTest.java
@@ -16,12 +16,16 @@
 
 package org.eclipse.microprofile.openapi.tck;
 
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
+
+import javax.ws.rs.core.MediaType;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -171,5 +175,34 @@ public class PetStoreAppTest extends AppTestBase {
         String authCode = "components.securitySchemes.petsOAuth2.flows.authorizationCode.";
         vr.body(authCode + "authorizationUrl", equalTo("https://example.com/api/oauth/dialog"));
         vr.body(authCode + "tokenUrl", equalTo("https://example.com/api/oauth/token"));
+    }
+
+    @RunAsClient
+    @Test
+    public void testDefaultResponseType() {
+        given()
+            .filter(AppTestBase.yamlFilter)
+        .when().get("/openapi")
+        .then()
+            .assertThat()
+                .statusCode(200)
+            .and()
+                .body("openapi", startsWith("3.0."));
+    }
+
+    @RunAsClient
+    @Test
+    public void testJsonResponseTypeWithQueryParameter() {
+        given()
+            .noFilters()
+            .queryParam("format", "JSON")
+        .when().get("/openapi")
+        .then()
+            .assertThat()
+                .contentType(MediaType.APPLICATION_JSON)
+            .and()
+                .statusCode(200)
+            .and()
+                .body("openapi", startsWith("3.0."));
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/utils/YamlToJsonFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/utils/YamlToJsonFilter.java
@@ -39,12 +39,6 @@ public class YamlToJsonFilter implements OrderedFilter {
 
     @Override
     public Response filter(FilterableRequestSpecification requestSpec, FilterableResponseSpecification responseSpec, FilterContext ctx) {
-
-        if (ContentType.JSON.matches(requestSpec.getContentType())) {
-            // Conversion is not needed
-            return ctx.next(requestSpec, responseSpec);
-        }
-
         try {
             Response response = ctx.next(requestSpec, responseSpec);
 


### PR DESCRIPTION
Fixes #307 

The current YAML response filter allows for JSON data, based on the `Content-Type` header. This change will require YAML formatted data whenever the request is not explicitly for JSON.

- Require YAML result for YAML request
- No longer apply YAML filter when JSON is expected
- Add test for when `Accept` header and `format` query param are both missing (expecting YAML)
- Add test for JSON `format` query param

Signed-off-by: Michael Edgar <michael@xlate.io>