### PR TITLE
Update to Jakarta EE dependencies, use provided for OSGi dependency

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -32,6 +32,7 @@
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.annotation.versioning</artifactId>
             <version>${osgi-annotation.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <maven-compiler-plugin.version>2.3.2</maven-compiler-plugin.version>
         <arquillian.version>1.1.13.Final</arquillian.version>
         <testng.version>7.0.0</testng.version>
-        <jaxrs.version>2.1</jaxrs.version>
+        <jaxrs.version>2.1.6</jaxrs.version>
         <rest-assured.version>3.0.6</rest-assured.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
         <java-hamcrest.version>2.0.0.0</java-hamcrest.version>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -32,6 +32,7 @@
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.annotation.versioning</artifactId>
             <version>${osgi-annotation.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -81,17 +81,29 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+            <version>${osgi-annotation.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>
             <artifactId>microprofile-openapi-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>
             <artifactId>microprofile-rest-client-api</artifactId>
             <version>${restclient.version}</version>
             <scope>provided</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         
         <dependency>
@@ -106,15 +118,22 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <version>${jaxrs.version}</version>
+            <scope>provided</scope>
         </dependency>
 
          <dependency>
              <groupId>io.rest-assured</groupId>
              <artifactId>rest-assured</artifactId>
              <version>${rest-assured.version}</version>
+             <exclusions>
+               <exclusion>
+                 <groupId>io.rest-assured</groupId>
+                 <artifactId>xml-path</artifactId>
+               </exclusion>
+             </exclusions>
          </dependency>
 
          <dependency>


### PR DESCRIPTION
Fixes #383 (same changes as were made in #396)
* Exclude unused dependencies from microprofile-rest-client-api and rest-assured that still use javax components.

Fixes #400 
* Mark OSGi dependency as `provided`. This requires the dependency to also be declared in the TCK module's POM.

Signed-off-by: Michael Edgar <michael@xlate.io>