### PR TITLE
Schema Registration Using Config Property

### DIFF
--- a/spec/src/main/asciidoc/microprofile-openapi-spec.adoc
+++ b/spec/src/main/asciidoc/microprofile-openapi-spec.adoc
@@ -93,29 +93,64 @@ https://github.com/eclipse/microprofile-open-api/blob/master/api/src/main/java/o
 
 The following is a list of configuration values that every vendor must support.
 
-[cols="1,4"]
-|===
-| Config key | Value description
+`mp.openapi.model.reader`::
+Configuration property to specify the fully qualified name of the <<OASModelReader>> implementation.
 
-| `mp.openapi.model.reader` | Configuration property to specify the fully qualified name of the <<OASModelReader>> implementation.
-| `mp.openapi.filter` | Configuration property to specify the fully qualified name of the <<OASFilter>> implementation.
-| `mp.openapi.scan.disable`  |  Configuration property to disable annotation scanning. Default value is `false`.
-| `mp.openapi.scan.packages`  |  Configuration property to specify the list of packages to scan. For example,
+`mp.openapi.filter`::
+Configuration property to specify the fully qualified name of the <<OASFilter>> implementation.
+
+`mp.openapi.scan.disable`::
+Configuration property to disable annotation scanning. Default value is `false`.
+
+`mp.openapi.scan.packages`:: 
+Configuration property to specify the list of packages to scan. For example,
 `mp.openapi.scan.packages=com.xyz.PackageA,com.xyz.PackageB`
-| `mp.openapi.scan.classes`  |  Configuration property to specify the list of classes to scan. For example,
+
+`mp.openapi.scan.classes`::
+Configuration property to specify the list of classes to scan. For example,
 `mp.openapi.scan.classes=com.xyz.MyClassA,com.xyz.MyClassB`
-| `mp.openapi.scan.exclude.packages`  |  Configuration property to specify the list of packages to exclude from scans. For example,
+
+`mp.openapi.scan.exclude.packages`::
+Configuration property to specify the list of packages to exclude from scans. For example,
 `mp.openapi.scan.exclude.packages=com.xyz.PackageC,com.xyz.PackageD`
-| `mp.openapi.scan.exclude.classes`  |  Configuration property to specify the list of classes to exclude from scans. For example,
+
+`mp.openapi.scan.exclude.classes`::
+Configuration property to specify the list of classes to exclude from scans. For example,
 `mp.openapi.scan.exclude.classes=com.xyz.MyClassC,com.xyz.MyClassD`
-| `mp.openapi.servers`  |  Configuration property to specify the list of global servers that provide connectivity information. For example,
+
+`mp.openapi.servers`::
+Configuration property to specify the list of global servers that provide connectivity information. For example,
 `mp.openapi.servers=https://xyz.com/v1,https://abc.com/v1`
-| `mp.openapi.servers.path.`   |  Prefix of the configuration property to specify an alternative list of servers to service all operations in a path. For example,
+
+`mp.openapi.servers.path.`::
+Prefix of the configuration property to specify an alternative list of servers to service all operations in a path. For example,
 `mp.openapi.servers.path./airlines/bookings/{id}=https://xyz.io/v1`
-| `mp.openapi.servers.operation.` | Prefix of the configuration property to specify an alternative list of servers to service an operation.
+
+`mp.openapi.servers.operation.`::
+Prefix of the configuration property to specify an alternative list of servers to service an operation.
 Operations that want to specify an alternative list of servers must define an `operationId`, a unique string used to identify the operation. For example,
 `mp.openapi.servers.operation.getBooking=https://abc.io/v1`
-|===
+
+`mp.openapi.schema.`::
+Prefix of the configuration property to specify a schema for a specific class, in JSON format.
+The remainder of the property key must be the fully-qualified class name. The value must be a valid OpenAPI schema object, 
+specified in the JSON format. The use of this property is functionally equivalent to the use of the `@Schema` annotation on
+a Java class, but may be used in cases where the application developer does not have access to the source code of a class. +
++
+When a `name` key is provided with a string value, the schema will be added to the `schemas` collection in the `components`
+object of the resulting OpenAPI document using ``name``'s value as the key.
++
+For example, in the case where an application wishes to represent Java ``Date``s in epoch milliseconds, the following configuration could be used (line 
+escapes and indentation added for readability):
+[source, json]
+----
+mp.openapi.schema.java.util.Date = { \
+  "name": "EpochMillis" \
+  "type": "number", \
+  "format": "int64", \
+  "description": "Milliseconds since January 1, 1970, 00:00:00 GMT" \
+}
+----
 
 ==== Vendor extensions
 

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/PetStoreApp.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/PetStoreApp.java
@@ -16,6 +16,7 @@ package org.eclipse.microprofile.openapi.apps.petstore;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.microprofile.openapi.annotations.Components;
 import org.eclipse.microprofile.openapi.annotations.ExternalDocumentation;
 import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
 import org.eclipse.microprofile.openapi.annotations.info.Contact;
@@ -23,7 +24,7 @@ import org.eclipse.microprofile.openapi.annotations.info.Info;
 import org.eclipse.microprofile.openapi.annotations.info.License;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
-
+import org.eclipse.microprofile.openapi.apps.petstore.model.Lizard;
 import org.eclipse.microprofile.openapi.apps.petstore.resource.PetResource;
 import org.eclipse.microprofile.openapi.apps.petstore.resource.PetStoreResource;
 import org.eclipse.microprofile.openapi.apps.petstore.resource.UserResource;
@@ -55,7 +56,11 @@ import javax.ws.rs.core.Application;
             externalDocs = @ExternalDocumentation(
                 url = "http://swagger.io", 
                 description="Find out more about our store"))
-    }
+    },
+    components = @Components(
+        schemas = { 
+            @Schema(name = "Lizard", implementation = Lizard.class)
+        })
 )
 @Schema(
     externalDocs = @ExternalDocumentation(

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/model/Pet.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/model/Pet.java
@@ -16,6 +16,7 @@ package org.eclipse.microprofile.openapi.apps.petstore.model;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import java.util.List;
+import java.time.Instant;
 import java.util.ArrayList;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -30,6 +31,7 @@ public class Pet {
     private List<String> photoUrls = new ArrayList<String>();
     private List<Tag> tags = new ArrayList<Tag>();
     private String status;
+    private Instant birthInstant;
 
     @XmlElement(name = "id")
     public long getId() {
@@ -91,5 +93,14 @@ public class Pet {
 
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    @XmlElement(name = "birthInstant")
+    public Instant getBirthInstant() {
+        return birthInstant;
+    }
+
+    public void setBirthInstant(Instant birthInstant) {
+        this.birthInstant = birthInstant;
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigSchemaTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigSchemaTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.eclipse.microprofile.openapi.tck;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
+
+import java.util.Map;
+
+import org.hamcrest.Matcher;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import io.restassured.response.ValidatableResponse;
+
+public class OASConfigSchemaTest extends AppTestBase {
+
+    @Deployment(name = "petstore")
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "petstore.war")
+                         .addPackages(true, "org.eclipse.microprofile.openapi.apps.petstore")
+                         .addAsWebInfResource("schema-microprofile-config.properties",
+                                              "classes/META-INF/microprofile-config.properties");
+    }
+
+    @RunAsClient
+    @Test(dataProvider = "formatProvider")
+    public void testSchemaConfigApplied(String type) {
+        ValidatableResponse vr = callEndpoint(type);
+
+        vr.body("components.schemas.EpochSeconds", epochSecondsSchema());
+        vr.body("components.schemas.Lizard.properties.birthInstant",
+                anyOf(epochSecondsSchema(), epochSecondsRef()));
+    }
+
+    private Matcher<Map<? extends String, ? extends String>> epochSecondsSchema() {
+        return allOf(aMapWithSize(4),
+                     hasEntry("title", "Epoch Seconds"),
+                     hasEntry("type", "number"),
+                     hasEntry("format", "int64"),
+                     hasEntry("description", "Number of seconds from the epoch of 1970-01-01T00:00:00Z"));
+    }
+
+    private Matcher<Map<? extends String, ? extends String>> epochSecondsRef() {
+        return allOf(aMapWithSize(1), hasEntry("$ref", "#/components/schemas/EpochSeconds"));
+    }
+}

--- a/tck/src/main/resources/schema-microprofile-config.properties
+++ b/tck/src/main/resources/schema-microprofile-config.properties
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+mp.openapi.schema.java.time.Instant = { \
+  "name": "EpochSeconds", \
+  "type": "number", \
+  "format": "int64", \
+  "title": "Epoch Seconds", \
+  "description": "Number of seconds from the epoch of 1970-01-01T00:00:00Z" \
+}


### PR DESCRIPTION
Fixes #364 

Add documentation and TCK test for `mp.openapi.schema.` configuration. Note that the list of property keys has changed from a table to a list to help readability.

Signed-off-by: Michael Edgar <michael@xlate.io>