### PR TITLE
Add missing OASConfig constant for schema configurations

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/OASConfig.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/OASConfig.java
@@ -85,6 +85,12 @@ public final class OASConfig {
     public static final String SERVERS_OPERATION_PREFIX = "mp.openapi.servers.operation.";
 
     /**
+     * Prefix of the configuration property to specify a schema for a specific class, in JSON format.
+     * 
+     */
+    public static final String SCHEMA_PREFIX = "mp.openapi.schema.";
+
+    /**
      * Recommended prefix for vendor specific configuration properties.
      * 
      */


### PR DESCRIPTION
This constant should have been included in #403 

Signed-off-by: Michael Edgar <michael@xlate.io>