### PR TITLE
Javadoc fix for JDK 11 build

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -42,6 +42,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
As you must have seen the github actions build for JDK 11 failed due to javadoc. This fix that.
Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>