### PR TITLE
Apply authors/email changes from 1.1.2, add authors for 2.0

### DIFF
--- a/spec/src/main/asciidoc/microprofile-openapi-spec.adoc
+++ b/spec/src/main/asciidoc/microprofile-openapi-spec.adoc
@@ -17,8 +17,7 @@
 // limitations under the License.
 //
 
-:authors: Arthur De Magalhaes (Spec Lead), Leo Christy Jesuraj, Eric Wittmann, Michael Glavassevich, Artur Dzmitryieu, Navid Shakibapour, Anna Safonov, Jana Manoharan, Paul Gooderham
-:email: ademagalhaes@gmail.com, leo.jesuraj@gmail.com, eric.wittmann@gmail.com, mrglavas@ca.ibm.com, dzmitry@ca.ibm.com, navid.shakibapour@gmail.com, anna.safonov@uoit.net, jana.manoharan96@gmail.com, turkeyonmarblerye@gmail.com
+:authors: Arthur De Magalhaes (Spec Lead), Eric Wittmann, Anna Safonov, Matt Gill, Ivan Junckes Filho, Jérémie Bresson, Jana Manoharan, Rui Qi Wang, Tommy Wojtczak, Martin Smithson, Michael Edgar
 :version-label!:
 :sectanchors:
 :doctype: book


### PR DESCRIPTION
A update was made to the specification authors in 5c5808d on the `1.x` branch that was not applied to `master`. Additionally, this PR adds those who made specification content changes since the 1.1.2 release, myself and @msmiths . If anyone would like additional authors to be included, please let me know and I can update the PR.

Signed-off-by: Michael Edgar <michael@xlate.io>