### PR TITLE
fixing build issue due to wrong TCK dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
         <httpclient.version>4.5.2</httpclient.version>
         <jackson.version>2.10.1</jackson.version>
-        <restclient.version>2.0</restclient.version>
+        <restclient.version>2.0-RC3</restclient.version>
 
         <!-- Versions of SPEC dependencies  -->
         <asciidoctor-maven.version>1.6.0</asciidoctor-maven.version>


### PR DESCRIPTION
commit 0352d7a1f4da489fbbe1aece72305d3a102ba174
Author: Bruno Tinoco <brunocrt@gmail.com>
Date:   Mon Dec 07 12:47:00 2020 GMT-3

    [458] Build Failing on TCK due to missing Rest Client version (2.0) on Maven Central
    
    When multiple projects are imported together, perform all the necessary
    auto shares in a single job rather than spawning a separate job for each
    project.
    
    Bug: https://github.com/eclipse/microprofile-open-api/issues/458
    Signed-off-by: Bruno Tinoco <brunocrt@gmail.com>