### PR TITLE
@SchemaProperty overrides implementation class attributes 

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/JAXRSApp.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/JAXRSApp.java
@@ -94,7 +94,7 @@ import org.eclipse.microprofile.openapi.apps.airlines.resources.bookings.Booking
                         @Schema(name = "id", type = SchemaType.INTEGER, format="int32"),
                         @Schema(name = "AirlinesRef", ref = "#/components/schemas/Airlines"),
                         @Schema(name = "User", implementation = User.class, properties = {
-                            @SchemaProperty(name = "phone", description = "Telephone number to contact the user")
+                            @SchemaProperty(name = "phone", description = "Telephone number to contact the user", example = "123-456-7891")
                         })},
                 responses = {
                         @APIResponse(name = "FoundAirlines", responseCode = "200", description = "successfully found airlines", 

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
@@ -667,8 +667,17 @@ public class AirlinesAppTest extends AppTestBase {
     public void testSchemaProperty(String type) {
         ValidatableResponse vr = callEndpoint(type);
         vr.body("components.schemas.User.properties", IsMapWithSize.aMapWithSize(10));
-        vr.body("components.schemas.User.properties.phone.example", equalTo("123-456-7890"));
+        vr.body("components.schemas.User.properties.phone.example", equalTo("123-456-7891"));
         vr.body("components.schemas.User.properties.phone.description", equalTo("Telephone number to contact the user"));
+    }
+    
+    @RunAsClient
+    @Test(dataProvider = "formatProvider")
+    public void testSchemaPropertyValuesOverrideClassPropertyValues(String type) {
+        ValidatableResponse vr = callEndpoint(type);
+        vr.body("components.schemas.User.properties", IsMapWithSize.aMapWithSize(10));
+        vr.body("components.schemas.User.properties.phone.example", not("123-456-7890"));
+        vr.body("components.schemas.User.properties.phone.example", equalTo("123-456-7891"));
     }
     
     @RunAsClient


### PR DESCRIPTION
Created in response to a [suggestion from](https://github.com/smallrye/smallrye-open-api/issues/621#issuecomment-755829630) @MikeEdgar within the [following issue](https://github.com/smallrye/smallrye-open-api/issues/621) rasied within the SmallRye OpenAPI repository. 

This PR adds an additional test to the tck, which verifies that the `@SchemaProperty` annotation overrides implementation class attributes, validating the behaviour for this annotation within the specification. 

