### PR TITLE
Remove broken ClassLoader delegation

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/spi/OASFactoryResolver.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/spi/OASFactoryResolver.java
@@ -89,18 +89,16 @@ public abstract class OASFactoryResolver {
             return null;
         }
 
-        OASFactoryResolver instance = loadSpi(cl.getParent());
+        OASFactoryResolver instance = null;
 
-        if (instance == null) {
-            ServiceLoader<OASFactoryResolver> sl = ServiceLoader.load(OASFactoryResolver.class, cl);
-            for (OASFactoryResolver spi : sl) {
-                if (instance != null) {
-                    throw new IllegalStateException("Multiple OASFactoryResolver implementations found: " + spi.getClass().getName() + " and "
-                            + instance.getClass().getName());
-                }
-                else {
-                    instance = spi;
-                }
+        ServiceLoader<OASFactoryResolver> sl = ServiceLoader.load(OASFactoryResolver.class, cl);
+        for (OASFactoryResolver spi : sl) {
+            if (instance != null) {
+                throw new IllegalStateException("Multiple OASFactoryResolver implementations found: " + spi.getClass().getName() + " and "
+                        + instance.getClass().getName());
+            }
+            else {
+                instance = spi;
             }
         }
         return instance;


### PR DESCRIPTION
It is up to the ClassLoader to do parent delegation,
we should not be second guessing it by attempting to
manually delegate to the parent. This manual
delegation breaks isolated class loading schemes.

Signed-off-by: Stuart Douglas <stuart.w.douglas@gmail.com>