### PR TITLE
Reverted Test for Map Scopes in OAuthFlow

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
@@ -783,17 +783,7 @@ public class ModelConstructionTest extends Arquillian {
     
     @Test
     public void oAuthFlowTest() {
-        final OAuthFlow o = processConstructible(OAuthFlow.class);
-        final String key = "myKey";
-        final String value = new String("myValue");
-        o.setScopes(Collections.singletonMap(key, value));
-        Map<String,String> scopes = o.getScopes().getScopes();
-        assertEquals(scopes.size(), 1, "The list is expected to contain one entry.");
-        assertTrue(scopes.containsKey("myKey"), "The map is expected to contain a 'myKey' entry.");
-        assertEquals(scopes.get(key), value, "The value corresponding to the 'myKey' is wrong.");
-        
-        o.setScopes((Map<String, String>) null);
-        assertNull(o.getScopes(), "The value is expected to be null.");
+        processConstructible(OAuthFlow.class);
     }
     
     @Test


### PR DESCRIPTION
Reverted this Test in the TCK:
https://github.com/eclipse/microprofile-open-api/commit/00da7732ecf1049d29aa04c91cc7e0476867883b#diff-b82b5f0adea3272f9d160a7ebd6ee8907099119261e1c7f45b111ef5d6a52909

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>