### PR TITLE
<fix>(417): Changed applicable context for ApiResponse and ApiResponses annotations

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponse.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponse.java
@@ -68,7 +68,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responseObject"
  * 
  **/
-@Target({ ElementType.METHOD })
+@Target({ ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @Repeatable(APIResponses.class)

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponses.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/responses/APIResponses.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * 
  * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responses-object">Responses Object</a>
  **/
-@Target({ ElementType.METHOD })
+@Target({ ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface APIResponses {


### PR DESCRIPTION
I really want this to be done in order to highly decrease amount of boilerplate in my project.

Fixes #417.

Thank you.