### PR TITLE
Use entry identity in list immutability check

### DIFF
--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -33,6 +33,7 @@ There are no functional changes introduced in this release, except the dependenc
 
 * Negative Test Scenario - @SchemaProperty Precedence Behaviour (link:https://github.com/eclipse/microprofile-open-api/issues/466[466])
 * Use MediaType.APPLICATION_JSON instead of application/json in some TCKs (link:https://github.com/eclipse/microprofile-open-api/pull/471[471])
+* TCK Tag Collection Test contains() side effect (link:https://github.com/eclipse/microprofile-open-api/issues/453[453])
 
 [[release_notes_20]]
 == Release Notes for Microprofile OpenAPI 2.0

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
@@ -1667,10 +1667,14 @@ public class ModelConstructionTest extends Arquillian {
         assertTrue(list.stream().anyMatch((v) -> v == value), "The list is expected to contain the value: " + value);
     }
 
+    private <T> void checkListEntryAbsent(List<T> list, T value) {
+        assertNotNull(list, "The list must not be null.");
+        assertTrue(list.stream().noneMatch((v) -> v == value), "The list is expected not to contain the value: " + value);
+    }
+
     private <O, V> void checkListImmutable(O container, Function<O, List<V>> listGetter, V otherValue) {
         List<V> list = listGetter.apply(container);
-        assertNotNull(list, "The list must not be null.");
-        assertFalse(list.contains(otherValue), "The list is expected to not contain the value: " + otherValue);
+        checkListEntryAbsent(list, otherValue);
         int originalSize = list.size();
         try {
             list.add(otherValue);
@@ -1678,8 +1682,7 @@ public class ModelConstructionTest extends Arquillian {
             // It is allowed to throw an exception
         }
         List<V> list2 = listGetter.apply(container);
-        assertNotNull(list2, "The list must not be null.");
-        assertFalse(list2.contains(otherValue), "The list is expected to not contain the value: " + otherValue);
+        checkListEntryAbsent(list2, otherValue);
         assertEquals(list2.size(), originalSize, "The list is expected to have a size of " + originalSize);
     }
 


### PR DESCRIPTION
Fixes #453 

The intent of the TCK helper method `checkListImmutable` is to assert that the third argument `otherValue` fails to be inserted to the list returned by the second argument `listGetter`. The current implementation utilizes `List#contains` for this assertion, but `contains` relies on `equals` whereas the test only needs to check object identity. Tests utilizing this method make no assertion regarding a vendor's implementation of `equals` on the objects in the list.