### PR TITLE
Enable UserResource in airlines app

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/JAXRSApp.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/JAXRSApp.java
@@ -51,6 +51,7 @@ import org.eclipse.microprofile.openapi.apps.airlines.model.User;
 import org.eclipse.microprofile.openapi.apps.airlines.resources.AirlinesResource;
 import org.eclipse.microprofile.openapi.apps.airlines.resources.AvailabilityResource;
 import org.eclipse.microprofile.openapi.apps.airlines.resources.ReviewResource;
+import org.eclipse.microprofile.openapi.apps.airlines.resources.UserResource;
 import org.eclipse.microprofile.openapi.apps.airlines.resources.bookings.BookingResource;
 
 import jakarta.ws.rs.ApplicationPath;
@@ -101,6 +102,7 @@ public class JAXRSApp extends Application {
         singletons.add(new AvailabilityResource());
         singletons.add(new BookingResource());
         singletons.add(new ReviewResource());
+        singletons.add(new UserResource());
         return singletons;
     }
 


### PR DESCRIPTION
Currently, the TCK verifies that the implementation creates paths and
operations for UserResource, even though it isn't configured as a rest
resource.

The spec doesn't demand that this should or shouldn't happen and it
makes sense for implementations to be allowed to check which resources
are actually included in the rest application and only generate schema
for those that are.

Fixes #498