### PR TITLE
Fixed links to the spec

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/info/Contact.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/info/Contact.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 /**
  * Contact information for the exposed API.
  * 
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.md#contactObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#contactObject"
  **/
 @Target({})
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/info/Info.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/info/Info.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 /**
  * This annotation provides metadata about the API, and maps to the Info object in OpenAPI Specification 3.
  * 
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.md#infoObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#infoObject"
  **/
 @Target({})
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/info/License.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/info/License.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 /**
  * License information for the exposed API.
  * 
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.md#licenseObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#licenseObject"
  **/
 @Target({})
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/media/Encoding.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/media/Encoding.java
@@ -27,7 +27,7 @@ import org.eclipse.microprofile.openapi.annotations.headers.Header;
 /**
  * Single encoding definition to be applied to single Schema Object
  * 
- * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.md#encodingObject">Encoding
+ * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#encodingObject">Encoding
  *      Object</a>
  **/
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/RequestBody.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/RequestBody.java
@@ -29,7 +29,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
  * Describes a single request body.
  * 
  * @see <a href=
- *      "https://github.com/OAI/OpenAPI-Specification/blob/3.0.0-rc2/versions/3.0.md#requestBodyObject">requestBody
+ *      "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#requestBodyObject">requestBody
  *      Object</a>
  **/
 @Target({ElementType.PARAMETER, ElementType.METHOD})

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/RequestBodySchema.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/parameters/RequestBodySchema.java
@@ -58,7 +58,7 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * @see RequestBody
- * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.0-rc2/versions/3.0.md#requestBodyObject">OpenAPI
+ * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#requestBodyObject">OpenAPI
  *      requestBody Object</a>
  **/
 @Target({ElementType.PARAMETER, ElementType.METHOD})

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/info/Contact.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/info/Contact.java
@@ -23,7 +23,7 @@ import org.eclipse.microprofile.openapi.models.Extensible;
 /**
  * This interface represents the Contact information for the exposed API.
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.md#contactObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#contactObject"
  */
 public interface Contact extends Constructible, Extensible<Contact> {
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/info/Info.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/info/Info.java
@@ -24,7 +24,7 @@ import org.eclipse.microprofile.openapi.models.Extensible;
  * This interface represents all the metadata about the API. The metadata may be used by clients if needed, and may be
  * presented in editing or documentation tools.
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.md#infoObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#infoObject"
  */
 public interface Info extends Constructible, Extensible<Info> {
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/info/License.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/info/License.java
@@ -23,7 +23,7 @@ import org.eclipse.microprofile.openapi.models.Extensible;
 /**
  * This interface represents the License information for the exposed API.
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.md#licenseObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#licenseObject"
  */
 public interface License extends Constructible, Extensible<License> {
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Encoding.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/media/Encoding.java
@@ -26,7 +26,7 @@ import org.eclipse.microprofile.openapi.models.headers.Header;
 /**
  * Encoding
  *
- * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.md#encodingObject">Encoding
+ * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#encodingObject">Encoding
  *      Object</a>
  */
 public interface Encoding extends Constructible, Extensible<Encoding> {

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/media/XML.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/media/XML.java
@@ -25,7 +25,7 @@ import org.eclipse.microprofile.openapi.models.Extensible;
  * inferred (for singular/plural forms) and the name property SHOULD be used to add that information.
  * <p>
  * 
- * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.0-rc2/versions/3.0.md#xmlObject">XML Object</a>
+ * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#xmlObject">XML Object</a>
  *      </p>
  */
 public interface XML extends Constructible, Extensible<XML> {

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/parameters/RequestBody.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/parameters/RequestBody.java
@@ -26,7 +26,7 @@ import org.eclipse.microprofile.openapi.models.media.Content;
  * This interface represents the request body of an operation in which body parameters can be specified.
  *
  * @see <a href=
- *      "https://github.com/OAI/OpenAPI-Specification/blob/3.0.0-rc2/versions/3.0.md#requestBodyObject">requestBody
+ *      "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#requestBodyObject">requestBody
  *      Object</a>
  */
 public interface RequestBody extends Constructible, Extensible<RequestBody>, Reference<RequestBody> {


### PR DESCRIPTION
The Open API spec links were broken.
This PR fixes them.