### PR TITLE
Update calendar (links for two TZs), update agenda/minutes link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,9 +40,8 @@ Do you want to contribute to this project? Here is what you can do:
 ** Make sure you have signed the https://www.eclipse.org/legal/ECA.php[Eclipse Contributor Agreement]
 * https://github.com/eclipse/microprofile-open-api/issues[Create or fix an issue].
 * https://gitter.im/eclipse/microprofile-open-api[Join us on Gitter to discuss this project].
-* Join our https://calendar.google.com/calendar/embed?src=gbnbc373ga40n0tvbl88nkc3r4%40group.calendar.google.com[bi-weekly meeting] every second Monday at https://www.timeanddate.com/time/map/[15h00 GMT]. 
-** https://docs.google.com/document/d/1opa5lz5m1IctTWNm09YWTb5qwg3r8zF9a0sPcOHCbt0/edit?usp=sharing[Minutes and Agenda].
-** https://bluejeans.com/166335599[Meeting room].
+* Join our weekly meeting (https://calendar.google.com/calendar/u/0/embed?src=gbnbc373ga40n0tvbl88nkc3r4%40group.calendar.google.com&ctz=UTC[UTC] / https://calendar.google.com/calendar/u/0/embed?src=gbnbc373ga40n0tvbl88nkc3r4%40group.calendar.google.com&ctz=America/New_York[US Eastern time]) every Monday.
+** https://docs.google.com/document/d/1lwrGcNTGnML4Aof0FyGVZCPaaNDBOoKLa5jivlVY1D8/edit?usp=sharing[Minutes and Agenda].
 * Join the discussions on the https://groups.google.com/forum/#!forum/microprofile[MicroProfile Google Group]
 * https://microprofile.io/blog/[Contribute a blog post].
 


### PR DESCRIPTION
Replace calendar link with separate links by time zone, update link to agenda/minutes document to current version.