### PR TITLE
Better support for security requirement objects

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/OpenAPIDefinition.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/OpenAPIDefinition.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Target;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.info.Info;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirementsSet;
 import org.eclipse.microprofile.openapi.annotations.servers.Server;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -67,10 +68,24 @@ public @interface OpenAPIDefinition {
 
     /**
      * A declaration of which security mechanisms can be used across the API.
-     *
-     * @return the array of servers used for this API
+     * <p>
+     * Adding a {@code SecurityRequirement} to this array is equivalent to adding a {@code SecurityRequirementsSet} containing
+     * a single {@code SecurityRequirement} to {@link #securitySets()}.
+     * 
+     * @return the array of security requirements for this API
      */
     SecurityRequirement[] security() default {};
+
+    /**
+     * A declaration of which security mechanisms can be used across the API.
+     * <p>
+     * All of the security requirements within any one of the sets must be satisfied to authorize a request.
+     * <p>
+     * Including an empty set within this list indicates that the other requirements are optional.
+     * 
+     * @return the array of security requirement sets for this API
+     */
+    SecurityRequirementsSet[] securitySets() default {};
 
     /**
      * Any additional external documentation for the API

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/callbacks/CallbackOperation.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/callbacks/CallbackOperation.java
@@ -28,6 +28,7 @@ import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirementsSet;
 
 /**
  * Describes a single API callback operation.
@@ -101,12 +102,28 @@ public @interface CallbackOperation {
      * A declaration of which security mechanisms can be used for this callback operation. Only one of the security
      * requirement objects need to be satisfied to authorize a request.
      * <p>
+     * Adding a {@code SecurityRequirement} to this array is equivalent to adding a {@code SecurityRequirementsSet}
+     * containing a single {@code SecurityRequirement} to {@link #securitySets()}.
+     * <p>
      * This definition overrides any declared top-level security. To remove a top-level security declaration, an empty
      * array can be used.
      * 
      * @return the list of security mechanisms for this callback operation
      */
     SecurityRequirement[] security() default {};
+
+    /**
+     * A declaration of which security mechanisms can be used for this callback operation. All of the security
+     * requirements within any one of the sets needs needs to be satisfied to authorize a request.
+     * <p>
+     * This definition overrides any declared top-level security. To remove a top-level security declaration, an empty
+     * array can be used.
+     * <p>
+     * Including an empty set within this list indicates that the other requirements are optional.
+     * 
+     * @return the list of security mechanisms for this callback operation
+     */
+    SecurityRequirementsSet[] securitySets() default {};
 
     /**
      * List of extensions to be added to the {@link org.eclipse.microprofile.openapi.models.Operation Operation} model

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityRequirement.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityRequirement.java
@@ -26,6 +26,9 @@ import java.lang.annotation.Target;
 
 /**
  * Specifies a security requirement for an operation.
+ * <p>
+ * Applying this annotation to a method or class is equivalent to applying a {@link SecurityRequirementsSet} annotation
+ * containing only this annotation.
  * 
  * @see <a href=
  *      "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#security-requirement-object">SecuirtyRequirement

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityRequirements.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityRequirements.java
@@ -23,8 +23,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This object represents an array of security requirements that can be specified for the operation or at definition
- * level. Only one of requirements needs be satisfied
+ * Container annotation for repeated {@link SecurityRequirement} annotations.
+ * <p>
+ * Note that <em>each</em> {@code SecurityRequirement} annotation is equivalent to a {@link SecurityRequirementsSet} annotation containing only that
+ * annotation.
  * 
  * <pre>
  * <b>Example:</b> 
@@ -42,7 +44,7 @@ import java.lang.annotation.Target;
 @Inherited
 public @interface SecurityRequirements {
     /**
-     * An array of SecurityRequirement annotations that can be specified for the operation or at definition level.
+     * An array of SecurityRequirement annotations
      *
      * @return the array of the SecurityRequirement annotations
      **/

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityRequirementsSet.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityRequirementsSet.java
@@ -18,13 +18,30 @@ package org.eclipse.microprofile.openapi.annotations.security;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
+
 /**
- * This object represents a map of security requirements that can be specified for the operation or at definition level.
- * All requirements in a set must be satisfied
+ * This annotation represents a set of security requirements which permit access to an operation if all of them are satisfied.
+ * <p>
+ * If this annotation is applied to a method which corresponds to an operation, then the requirements will be added to that operation.
+ * <p>
+ * If this annotation is applied to a class which contains methods which correspond to operations, then the requirements will be added to all
+ * operations corresponding to methods within that class which don't specify any other requirements.
+ * <p>
+ * Security requirements can be specified for the whole API using {@link OpenAPIDefinition#securitySets()}. Security requirements specified
+ * for individual operations override those specified for the whole API.
+ * <p>
+ * If multiple security requirement sets are specified for an operation, then a user must satisfy all of the requirements within any one of the sets
+ * to access the operation.
+ * <p>
+ * An empty security requirement set indicates that authentication is not required.
+ * <p>
+ * A {@code SecurityRequirementSet} annotation corresponds to a map of security requirements in an OpenAPI document.
  * 
  * <pre>
  * <b>Example:</b> 
@@ -34,17 +51,18 @@ import java.lang.annotation.Target;
  * </pre>
  * 
  * @see <a href=
- *      "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#security-requirement-object">SecurityRequirement
- *      Object</a>
+ * "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#security-requirement-object">SecurityRequirement
+ * Object</a>
  **/
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
+@Repeatable(SecurityRequirementsSets.class)
 @Inherited
 public @interface SecurityRequirementsSet {
     /**
-     * An array of SecurityRequirement annotations that can be specified for the operation or at definition level.
+     * The security requirements which make up the set
      *
-     * @return the array of the SecurityRequirement annotations
+     * @return the array of the SecurityRequirement annotations, may be empty
      **/
     SecurityRequirement[] value() default {};
 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityRequirementsSets.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityRequirementsSets.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.openapi.annotations.security;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Represents an array of security requirement sets that apply to an operation. Only one of requirement sets needs be satisfied to access the
+ * operation.
+ * <p>
+ * If this annotation is applied to a method which corresponds to an operation, then the requirements will be added to that operation.
+ * <p>
+ * If this annotation is applied to a class which contains methods which correspond to operations, then the requirements will be added to all
+ * operations corresponding to methods within that class which don't specify any other requirements.
+ * <p>
+ * This annotation may be used with {@code value} set to an empty array. When applied like this to a method or class, it indicates that no security
+ * requirements apply to the corresponding operations. This can be used to override security requirements which are specified for the whole API.
+ * <p>
+ * A {@code SecurityRequirementSets} annotation corresponds to an array of maps of security requirements in an OpenAPI document.
+ * <pre>
+ * <b>Example:</b> 
+ * security: 
+ *   - oauth_implicit: []
+ *     http_basic: []
+ *   - api_secret: []
+ * </pre>
+ * 
+ * @see <a href=
+ *      "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#security-requirement-object">SecurityRequirement
+ *      Object</a>
+ **/
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
+@Inherited
+public @interface SecurityRequirementsSets {
+
+    /**
+     * An array of SecurityRequirementSet annotations
+     *
+     * @return the array of the SecurityRequirementSet annotations
+     **/
+    SecurityRequirementsSet[] value() default {};
+}

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/JAXRSApp.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/JAXRSApp.java
@@ -40,6 +40,7 @@ import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirementsSet;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
 import org.eclipse.microprofile.openapi.annotations.servers.Server;
 import org.eclipse.microprofile.openapi.annotations.servers.ServerVariable;
@@ -63,13 +64,16 @@ import jakarta.ws.rs.core.MediaType;
         @Tag(name = "user", description = "Operations about user"),
         @Tag(name = "create", description = "Operations about create"),
         @Tag(name = "Bookings", description = "All the bookings methods")
-}, externalDocs = @ExternalDocumentation(description = "instructions for how to deploy this app", url = "https://github.com/microservices-api/oas3-airlines/blob/master/README.md"), info = @Info(title = "AirlinesRatingApp API", version = "1.0", termsOfService = "http://airlinesratingapp.com/terms", contact = @Contact(name = "AirlinesRatingApp API Support", url = "http://exampleurl.com/contact", email = "techsupport@airlinesratingapp.com"), license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html")), security = @SecurityRequirement(name = "airlinesRatingApp_auth"), servers = {
+}, externalDocs = @ExternalDocumentation(description = "instructions for how to deploy this app", url = "https://github.com/microservices-api/oas3-airlines/blob/master/README.md"), info = @Info(title = "AirlinesRatingApp API", version = "1.0", termsOfService = "http://airlinesratingapp.com/terms", contact = @Contact(name = "AirlinesRatingApp API Support", url = "http://exampleurl.com/contact", email = "techsupport@airlinesratingapp.com"), license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html")), security = @SecurityRequirement(name = "airlinesRatingApp_auth"), securitySets = @SecurityRequirementsSet({
+        @SecurityRequirement(name = "testScheme1"), @SecurityRequirement(name = "testScheme2")
+}), servers = {
         @Server(url = "https://{username}.gigantic-server.com:{port}/{basePath}", description = "The production API server", variables = {
                 @ServerVariable(name = "username", description = "Reviews of the app by users", defaultValue = "user1", enumeration = {
                         "user1", "user2"}),
                 @ServerVariable(name = "port", description = "Booking data", defaultValue = "8443"),
                 @ServerVariable(name = "user", description = "User data", defaultValue = "user"),
-                @ServerVariable(name = "basePath", defaultValue = "v2")}),
+                @ServerVariable(name = "basePath", defaultValue = "v2")
+        }),
         @Server(url = "https://test-server.com:80/basePath", description = "The test API server")}, components = @Components(schemas = {
                 @Schema(name = "Bookings", title = "Bookings", type = SchemaType.ARRAY, implementation = Booking.class),
                 @Schema(name = "Airlines", title = "Airlines", type = SchemaType.ARRAY, implementation = Airline.class),
@@ -77,22 +81,33 @@ import jakarta.ws.rs.core.MediaType;
                 @Schema(name = "AirlinesRef", ref = "#/components/schemas/Airlines"),
                 @Schema(name = "User", implementation = User.class, properties = {
                         @SchemaProperty(name = "phone", description = "Telephone number to contact the user", example = "123-456-7891")
-                })}, responses = {
-                        @APIResponse(name = "FoundAirlines", responseCode = "200", description = "successfully found airlines", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = SchemaType.ARRAY, implementation = Airline.class))),
-                        @APIResponse(name = "FoundBookings", responseCode = "200", description = "Bookings retrieved", content = @Content(schema = @Schema(type = SchemaType.ARRAY, implementation = Booking.class)))}, parameters = {
-                                @Parameter(name = "departureDate", in = ParameterIn.QUERY, required = true, description = "Customer departure date", schema = @Schema(implementation = String.class)),
-                                @Parameter(name = "username", in = ParameterIn.QUERY, description = "The name that needs to be deleted", schema = @Schema(type = SchemaType.STRING), required = true)}, examples = {
-                                        @ExampleObject(name = "review", summary = "External review example", description = "This example exemplifies the content on our site.", externalValue = "http://foo.bar/examples/review-example.json"),
-                                        @ExampleObject(name = "user", summary = "External user example", externalValue = "http://foo.bar/examples/user-example.json")}, requestBodies = {
-                                                @RequestBody(name = "review", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Review.class)), required = true, description = "example review to add")}, headers = {
-                                                        @Header(name = "Max-Rate", description = "Maximum rate", schema = @Schema(type = SchemaType.INTEGER), required = true, allowEmptyValue = true, deprecated = true),
-                                                        @Header(name = "Request-Limit", description = "The number of allowed requests in the current period", schema = @Schema(type = SchemaType.INTEGER))}, securitySchemes = {
-                                                                @SecurityScheme(securitySchemeName = "httpTestScheme", description = "user security scheme", type = SecuritySchemeType.HTTP, scheme = "testScheme")}, links = {
-                                                                        @Link(name = "UserName", description = "The username corresponding to provided user id", operationId = "getUserByName", parameters = @LinkParameter(name = "userId", expression = "$request.path.id"))}, callbacks = {
-                                                                                @Callback(name = "GetBookings", callbackUrlExpression = "http://localhost:9080/airlines/bookings", operations = @CallbackOperation(summary = "Retrieve all bookings for current user", responses = {
-                                                                                        @APIResponse(ref = "FoundBookings")}))
-                                                                        }))
+                })
+        }, responses = {
+                @APIResponse(name = "FoundAirlines", responseCode = "200", description = "successfully found airlines", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = SchemaType.ARRAY, implementation = Airline.class))),
+                @APIResponse(name = "FoundBookings", responseCode = "200", description = "Bookings retrieved", content = @Content(schema = @Schema(type = SchemaType.ARRAY, implementation = Booking.class)))
+        }, parameters = {
+                @Parameter(name = "departureDate", in = ParameterIn.QUERY, required = true, description = "Customer departure date", schema = @Schema(implementation = String.class)),
+                @Parameter(name = "username", in = ParameterIn.QUERY, description = "The name that needs to be deleted", schema = @Schema(type = SchemaType.STRING), required = true)
+        }, examples = {
+                @ExampleObject(name = "review", summary = "External review example", description = "This example exemplifies the content on our site.", externalValue = "http://foo.bar/examples/review-example.json"),
+                @ExampleObject(name = "user", summary = "External user example", externalValue = "http://foo.bar/examples/user-example.json")
+        }, requestBodies = {
+                @RequestBody(name = "review", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Review.class)), required = true, description = "example review to add")
+        }, headers = {
+                @Header(name = "Max-Rate", description = "Maximum rate", schema = @Schema(type = SchemaType.INTEGER), required = true, allowEmptyValue = true, deprecated = true),
+                @Header(name = "Request-Limit", description = "The number of allowed requests in the current period", schema = @Schema(type = SchemaType.INTEGER))
+        }, securitySchemes = {
+                @SecurityScheme(securitySchemeName = "httpTestScheme", description = "user security scheme", type = SecuritySchemeType.HTTP, scheme = "testScheme")
+        }, links = {
+                @Link(name = "UserName", description = "The username corresponding to provided user id", operationId = "getUserByName", parameters = @LinkParameter(name = "userId", expression = "$request.path.id"))
+        }, callbacks = {
+                @Callback(name = "GetBookings", callbackUrlExpression = "http://localhost:9080/airlines/bookings", operations = @CallbackOperation(summary = "Retrieve all bookings for current user", responses = {
+                        @APIResponse(ref = "FoundBookings")
+                }))
+        }))
 @SecurityScheme(securitySchemeName = "airlinesRatingApp_auth", description = "authentication needed to access Airlines app", type = SecuritySchemeType.APIKEY, apiKeyName = "api_key", in = SecuritySchemeIn.HEADER)
+@SecurityScheme(securitySchemeName = "testScheme1", type = SecuritySchemeType.APIKEY, apiKeyName = "test1", in = SecuritySchemeIn.HEADER)
+@SecurityScheme(securitySchemeName = "testScheme2", type = SecuritySchemeType.HTTP, scheme = "Basic")
 @Schema(name = "AirlinesRatingApp API", description = "APIs for booking and managing air flights", externalDocs = @ExternalDocumentation(description = "For more information, see the link.", url = "http://exampleurl.com/schema"))
 public class JAXRSApp extends Application {
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/UserResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/UserResource.java
@@ -225,6 +225,8 @@ public class UserResource {
 
     @SecurityScheme(ref = "#/components/securitySchemes/httpTestScheme")
     @SecurityRequirement(name = "httpTestScheme")
+    @SecurityRequirementsSet({@SecurityRequirement(name = "testScheme1"), @SecurityRequirement(name = "testScheme2")})
+    @SecurityRequirementsSet
     public Response loginUser(
             @Parameter(name = "username", description = "The user name for login", schema = @Schema(type = SchemaType.STRING), required = true) @QueryParam("username") String username,
             @Parameter(name = "password", description = "The password for login in clear text", schema = @Schema(type = SchemaType.STRING), required = true) @QueryParam("password") String password) {

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
@@ -16,6 +16,8 @@
 
 package org.eclipse.microprofile.openapi.tck;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -496,7 +498,14 @@ public class AirlinesAppTest extends AppTestBase {
     @Test(dataProvider = "formatProvider")
     public void testSecurityRequirement(String type) {
         ValidatableResponse vr = callEndpoint(type);
-        vr.body("security.airlinesRatingApp_auth[0][0]", equalTo(null));
+        vr.body("security", containsInAnyOrder(
+                allOf(
+                        aMapWithSize(1),
+                        hasEntry(equalTo("airlinesRatingApp_auth"), empty())),
+                allOf(
+                        aMapWithSize(2),
+                        hasEntry(equalTo("testScheme1"), empty()),
+                        hasEntry(equalTo("testScheme2"), empty()))));
 
         vr.body("paths.'/reviews'.post.security.reviewoauth2[0][0]", equalTo("write:reviews"));
         vr.body("paths.'/reviews'.post.security.reviewoauth2", hasSize(1));
@@ -506,9 +515,24 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/reviews'.post.security.bookingSecurityScheme", hasSize(1));
         vr.body("paths.'/bookings'.post.security.bookingSecurityScheme[0]", hasSize(2));
 
-        vr.body("paths.'/user'.post.security.httpSchemeForTest[0][0]", equalTo(null));
+        vr.body("paths.'/user'.post.security", hasSize(1));
+        vr.body("paths.'/user'.post.security[0].keySet()", contains("httpSchemeForTest"));
+        vr.body("paths.'/user'.post.security[0].httpSchemeForTest", hasSize(0));
 
-        vr.body("paths.'/user/login'.get.security.find { it.httpTestScheme != null }.httpTestScheme", empty());
+        vr.body("paths.'/user/login'.get.security", containsInAnyOrder(
+                allOf(
+                        aMapWithSize(1),
+                        hasEntry(equalTo("httpTestScheme"), empty())),
+                allOf(
+                        aMapWithSize(2),
+                        hasEntry(equalTo("testScheme1"), empty()),
+                        hasEntry(equalTo("testScheme2"), empty())),
+                anEmptyMap()));
+
+        vr.body("paths.'/user/{username}'.patch.security", contains(
+                allOf(aMapWithSize(2),
+                        hasEntry(equalTo("userApiKey"), empty()),
+                        hasEntry(equalTo("userBearerHttp"), empty()))));
     }
 
     @RunAsClient
@@ -935,15 +959,15 @@ public class AirlinesAppTest extends AppTestBase {
 
         vr.body(params + ".find{ it.name == 'minRating' }", hasEntry(equalTo("in"), equalTo("query")));
         vr.body(params + ".find{ it.name == 'minRating' }", either(not(hasKey("required")))
-            .or(hasEntry(equalTo("required"), equalTo(false))));
+                .or(hasEntry(equalTo("required"), equalTo(false))));
 
         vr.body(params + ".find{ it.name == 'If-Match' }", hasEntry(equalTo("in"), equalTo("header")));
         vr.body(params + ".find{ it.name == 'If-Match' }", either(not(hasKey("required")))
-            .or(hasEntry(equalTo("required"), equalTo(false))));
+                .or(hasEntry(equalTo("required"), equalTo(false))));
 
         vr.body(params + ".find{ it.name == 'trackme' }", hasEntry(equalTo("in"), equalTo("cookie")));
         vr.body(params + ".find{ it.name == 'trackme' }", either(not(hasKey("required")))
-            .or(hasEntry(equalTo("required"), equalTo(false))));
+                .or(hasEntry(equalTo("required"), equalTo(false))));
     }
 
     @RunAsClient


### PR DESCRIPTION
* Make `SecurityRequirementsSet` repeatable
* Add `securitySet` parameters to OpenAPIDefinition and CallbackOperation
* Clarify that using `@SecurityRequirement` alone is equivalent to using
`@SecurityRequirementsSet` with one element
* Add TCK for `@SecurityRequirementsSet`
* Add TCK for `securitySet` in `@OpenAPIDefinition`

Fixes #468 
Fixes #483 