### PR TITLE
Tests for hidden schemas

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/model/User.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/model/User.java
@@ -48,6 +48,9 @@ public class User {
     @Schema(required = true, example = "1")
     private int status;
 
+    @Schema(hidden = true)
+    private String undocumentedProperty;
+
     /**
      * Creates a User instance with the parameters specified.
      * 
@@ -277,6 +280,14 @@ public class User {
      */
     public void setUserStatus(int status) {
         this.status = status;
+    }
+
+    public String getUndocumentedProperty() {
+        return undocumentedProperty;
+    }
+
+    public void setUndocumentedProperty(String undocumentedProperty) {
+        this.undocumentedProperty = undocumentedProperty;
     }
 
 }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/UserResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/UserResource.java
@@ -242,4 +242,17 @@ public class UserResource {
     public Response logoutUser() {
         return Response.ok().entity("").build();
     }
+
+    /**
+     * Operation to test hiding of request body and parameter schemas
+     * 
+     * @return a user
+     */
+    @POST
+    @Path("/special")
+    public User specialOperation(@Schema(hidden = true) User body,
+            @Schema(hidden = true) @QueryParam("param1") String param1) {
+        return body;
+    }
+
 }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
@@ -23,11 +23,14 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
@@ -281,6 +284,10 @@ public class AirlinesAppTest extends AppTestBase {
                 equalTo("This changes the password for the logged in user."));
         vr.body("paths.'/user/{username}'.patch.operationId", equalTo("changePassword"));
         vr.body("paths.'/user/{username}'.patch.parameters", hasSize(3));
+
+        // Operation with hidden schemas
+        vr.body("paths.'/user/special'.post.requestBody.content.'application/json'.schema", is(nullValue()));
+        vr.body("paths.'/user/special'.post.parameters[0].schema", is(nullValue()));
     }
 
     @RunAsClient
@@ -664,6 +671,7 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/user'.post.requestBody.content.'application/json'.schema.maxProperties", equalTo(1024));
         vr.body("paths.'/user'.post.requestBody.content.'application/json'.schema.minProperties", equalTo(1));
         vr.body("components.schemas.User.required", hasItems("id", "username", "password")); // requiredProperties
+        vr.body("components.schemas.User", not(hasItem("undocumentedProperty"))); // hidden property
         vr.body("components.schemas.Gender.enum", hasItems("Male", "Female", "Other"));
 
         // Array properties

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassTest.java
@@ -47,7 +47,7 @@ public class OASConfigExcludeClassTest extends AppTestBase {
         vr.body("openapi", startsWith("3.0."));
         vr.body("info.title", equalTo("AirlinesRatingApp API"));
         vr.body("info.version", equalTo("1.0"));
-        vr.body("paths.", aMapWithSize(11));
+        vr.body("paths.", aMapWithSize(12));
         vr.body("paths.'/reviews'", nullValue());
         vr.body("paths.'/reviews/{id}'", nullValue());
         vr.body("paths.'/reviews/users/{user}'", nullValue());

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludeClassesTest.java
@@ -48,7 +48,7 @@ public class OASConfigExcludeClassesTest extends AppTestBase {
         vr.body("info.title", equalTo("AirlinesRatingApp API"));
         vr.body("info.version", equalTo("1.0"));
 
-        vr.body("paths.", aMapWithSize(10));
+        vr.body("paths.", aMapWithSize(11));
         vr.body("paths.'/reviews'", nullValue());
         vr.body("paths.'/reviews/{id}'", nullValue());
         vr.body("paths.'/reviews/users/{user}'", nullValue());

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludePackageTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigExcludePackageTest.java
@@ -47,7 +47,7 @@ public class OASConfigExcludePackageTest extends AppTestBase {
         vr.body("openapi", startsWith("3.0."));
         vr.body("info.title", equalTo("AirlinesRatingApp API"));
         vr.body("info.version", equalTo("1.0"));
-        vr.body("paths", aMapWithSize(14));
+        vr.body("paths", aMapWithSize(15));
         vr.body("paths.'/bookings'", nullValue());
         vr.body("paths.'/bookings/{id}'", nullValue());
 


### PR DESCRIPTION
* Test that a field annotated with @Schema(hidden = true) is not
  included in the schema for the enclosing class
* Test that a resource method parameter annotated with @QueryParam and
  @Schema(hidden = true) creates a parameter with no schema in the
  openapi document
* Test that a resource method parameter annotated with @Schema(hidden =
  true) creates a request body with no schema in the openapi document

I wasn't hugely happy with this issue, the spec isn't clear what "hidden" means and it's hard to interpret for all the locations that the `@Schema` annotation could be applied. The lack of structure in the TCKs is also unhelpful in deciding how to add or structure a new set of tests.

In the end I've tested `hidden = true` in the scenarios listed above and required that the `schema` parameter is not present in the openapi document which seems reasonable, but it could also be tested in the following locations:

* Applied to a class which is used as a field in a different class
* Applied to a class which is used as a request body
* Applied to a class which is used as a request parameter
* Applied to a class which is used as a response body
* Applied to a resource method (where it would affect the response body)

Fixes #508 