### PR TITLE
Only require the endpoint when an OpenAPI document can be generated

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/OpenAPIDefinition.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/OpenAPIDefinition.java
@@ -69,8 +69,8 @@ public @interface OpenAPIDefinition {
     /**
      * A declaration of which security mechanisms can be used across the API.
      * <p>
-     * Adding a {@code SecurityRequirement} to this array is equivalent to adding a {@code SecurityRequirementsSet} containing
-     * a single {@code SecurityRequirement} to {@link #securitySets()}.
+     * Adding a {@code SecurityRequirement} to this array is equivalent to adding a {@code SecurityRequirementsSet}
+     * containing a single {@code SecurityRequirement} to {@link #securitySets()}.
      * 
      * @return the array of security requirements for this API
      */

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityRequirements.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityRequirements.java
@@ -25,8 +25,8 @@ import java.lang.annotation.Target;
 /**
  * Container annotation for repeated {@link SecurityRequirement} annotations.
  * <p>
- * Note that <em>each</em> {@code SecurityRequirement} annotation is equivalent to a {@link SecurityRequirementsSet} annotation containing only that
- * annotation.
+ * Note that <em>each</em> {@code SecurityRequirement} annotation is equivalent to a {@link SecurityRequirementsSet}
+ * annotation containing only that annotation.
  * 
  * <pre>
  * <b>Example:</b> 

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityRequirementsSet.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityRequirementsSet.java
@@ -26,18 +26,21 @@ import java.lang.annotation.Target;
 import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
 
 /**
- * This annotation represents a set of security requirements which permit access to an operation if all of them are satisfied.
+ * This annotation represents a set of security requirements which permit access to an operation if all of them are
+ * satisfied.
  * <p>
- * If this annotation is applied to a method which corresponds to an operation, then the requirements will be added to that operation.
+ * If this annotation is applied to a method which corresponds to an operation, then the requirements will be added to
+ * that operation.
  * <p>
- * If this annotation is applied to a class which contains methods which correspond to operations, then the requirements will be added to all
- * operations corresponding to methods within that class which don't specify any other requirements.
+ * If this annotation is applied to a class which contains methods which correspond to operations, then the requirements
+ * will be added to all operations corresponding to methods within that class which don't specify any other
+ * requirements.
  * <p>
- * Security requirements can be specified for the whole API using {@link OpenAPIDefinition#securitySets()}. Security requirements specified
- * for individual operations override those specified for the whole API.
+ * Security requirements can be specified for the whole API using {@link OpenAPIDefinition#securitySets()}. Security
+ * requirements specified for individual operations override those specified for the whole API.
  * <p>
- * If multiple security requirement sets are specified for an operation, then a user must satisfy all of the requirements within any one of the sets
- * to access the operation.
+ * If multiple security requirement sets are specified for an operation, then a user must satisfy all of the
+ * requirements within any one of the sets to access the operation.
  * <p>
  * An empty security requirement set indicates that authentication is not required.
  * <p>
@@ -51,8 +54,8 @@ import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
  * </pre>
  * 
  * @see <a href=
- * "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#security-requirement-object">SecurityRequirement
- * Object</a>
+ *      "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#security-requirement-object">SecurityRequirement
+ *      Object</a>
  **/
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityRequirementsSets.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/security/SecurityRequirementsSets.java
@@ -24,18 +24,23 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * Represents an array of security requirement sets that apply to an operation. Only one of requirement sets needs be satisfied to access the
- * operation.
+ * Represents an array of security requirement sets that apply to an operation. Only one of requirement sets needs be
+ * satisfied to access the operation.
  * <p>
- * If this annotation is applied to a method which corresponds to an operation, then the requirements will be added to that operation.
+ * If this annotation is applied to a method which corresponds to an operation, then the requirements will be added to
+ * that operation.
  * <p>
- * If this annotation is applied to a class which contains methods which correspond to operations, then the requirements will be added to all
- * operations corresponding to methods within that class which don't specify any other requirements.
+ * If this annotation is applied to a class which contains methods which correspond to operations, then the requirements
+ * will be added to all operations corresponding to methods within that class which don't specify any other
+ * requirements.
  * <p>
- * This annotation may be used with {@code value} set to an empty array. When applied like this to a method or class, it indicates that no security
- * requirements apply to the corresponding operations. This can be used to override security requirements which are specified for the whole API.
+ * This annotation may be used with {@code value} set to an empty array. When applied like this to a method or class, it
+ * indicates that no security requirements apply to the corresponding operations. This can be used to override security
+ * requirements which are specified for the whole API.
  * <p>
- * A {@code SecurityRequirementSets} annotation corresponds to an array of maps of security requirements in an OpenAPI document.
+ * A {@code SecurityRequirementSets} annotation corresponds to an array of maps of security requirements in an OpenAPI
+ * document.
+ * 
  * <pre>
  * <b>Example:</b> 
  * security: 

--- a/spec/src/main/asciidoc/microprofile-openapi-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-openapi-spec.asciidoc
@@ -700,8 +700,14 @@ from the current model.
 == OpenAPI Endpoint
 
 === Overview
-A fully processed OpenAPI document must be available at the root
-URL `/openapi`, as a `HTTP GET` operation.
+A fully processed OpenAPI document must be served from the root
+URL `/openapi` in response to an `HTTP GET` request if any of the
+following conditions are met:
+
+- an `OASModelReader` has been configured with `mp.openapi.model.reader`
+- an `OASFilter` has been configured with `mp.openapi.filter`
+- one of the allowed static files is present, i.e. `META-INF/openapi.(json|yaml)`
+- the application uses JAX-RS
 
 For example, `GET http://myHost:myPort/openapi`.
 


### PR DESCRIPTION
This allows the endpoint not to be served if the user isn't deploying an
application which uses Jakarta RESTful WS and hasn't supplied an OpenAPI
document in another way.

The auto-formatter wants to reformat the changes from #525 so I've included that as a separate commit.

Fixes #413 