### PR TITLE
Test a Bean Validation annotation on a parameter

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/beanvalidation/BeanValidationResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/beanvalidation/BeanValidationResource.java
@@ -16,9 +16,11 @@
 package org.eclipse.microprofile.openapi.apps.beanvalidation;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.core.MediaType;
 
 @Path("/")
@@ -27,5 +29,10 @@ public class BeanValidationResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     public void test(@Valid BeanValidationData data) {
+    }
+
+    @POST
+    @Path("parameter/{test}")
+    public void test(@PathParam("test") @Size(max = 6) String size) {
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/beanvalidation/BeanValidationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/beanvalidation/BeanValidationTest.java
@@ -195,6 +195,15 @@ public class BeanValidationTest extends AppTestBase {
         assertProperty(vr, "defaultAndOtherGroups", hasEntry("minLength", 1));
     }
 
+    @Test(dataProvider = "formatProvider")
+    @RunAsClient
+    public void parameterTest(String format) {
+        ValidatableResponse vr = callEndpoint(format);
+        String schemaPath = dereference(vr, "paths.'/parameter/{test}'.post.parameters[0]", "schema");
+        vr.body(schemaPath, hasEntry("maxLength", 6));
+        vr.body(schemaPath, hasEntry("type", "string"));
+    }
+
     /**
      * Asserts that a property from the test schema matches the given matcher
      * 


### PR DESCRIPTION
Add a test for a BeanValidation annotation added to a resource method parameter.

We already have tests for each supported bean validation annotation, but we only test them applied to a field. This test checks that the implementation also looks for BV annotations on a resource method parameter.

For #482 