### PR TITLE
Test security and securitySet in CallbackOperation

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/ReviewResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/ReviewResource.java
@@ -41,6 +41,7 @@ import org.eclipse.microprofile.openapi.annotations.security.OAuthFlow;
 import org.eclipse.microprofile.openapi.annotations.security.OAuthFlows;
 import org.eclipse.microprofile.openapi.annotations.security.OAuthScope;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirementsSet;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
 import org.eclipse.microprofile.openapi.annotations.servers.Server;
 import org.eclipse.microprofile.openapi.annotations.servers.ServerVariable;
@@ -268,7 +269,14 @@ public class ReviewResource {
                                                                                                   schema = @Schema(type = SchemaType.ARRAY,
                                                                                                                    implementation = Review.class))),
                                                       extensions = @Extension(name = "x-callback-operation",
-                                                                              value = "test-callback-operation")),
+                                                                              value = "test-callback-operation"),
+                                                      security = @SecurityRequirement(name = "httpTestScheme"),
+                                                      securitySets = {@SecurityRequirementsSet({
+                                                              @SecurityRequirement(name = "testScheme1"),
+                                                              @SecurityRequirement(name = "testScheme2")
+                                                      }),
+                                                              @SecurityRequirementsSet()
+                                                      }),
                       extensions = @Extension(name = "x-callback", value = "test-callback"))
     })
     @Tag(ref = "Reviews")

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
@@ -566,6 +566,18 @@ public class AirlinesAppTest extends AppTestBase {
 
     @RunAsClient
     @Test(dataProvider = "formatProvider")
+    public void testSecuirtyRequirementInCallback(String type) {
+        ValidatableResponse vr = callEndpoint(type);
+        String callbackOpPath =
+                "paths.'/reviews'.post.callbacks.testCallback.'http://localhost:9080/oas3-airlines/reviews'.get";
+        vr.body(callbackOpPath + ".security", containsInAnyOrder(
+                hasKey("httpTestScheme"),
+                allOf(hasKey("testScheme1"), hasKey("testScheme2")),
+                anEmptyMap()));
+    }
+
+    @RunAsClient
+    @Test(dataProvider = "formatProvider")
     public void testSecuritySchemes(String type) {
         ValidatableResponse vr = callEndpoint(type);
         String s = "components.securitySchemes";


### PR DESCRIPTION
These tests were missed when we added the new `securitySet` attribute to `@CallbackOperation`. I didn't see an existing test for the `security` attribute so I added that too.

For #468 