### PR TITLE
Limit Bean Validation processing requirement

### DIFF
--- a/spec/src/main/asciidoc/microprofile-openapi-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-openapi-spec.asciidoc
@@ -589,7 +589,8 @@ For more samples please see the https://github.com/eclipse/microprofile-open-api
 
 In some cases, additional schema restrictions can be inferred from Jakarta Bean Validation annotations and used to enhance the generated OpenAPI document.
 
-Implementations are required to process Jakarta Bean Validation annotations and add the properties listed in the table below to the schema model when:
+If an implementation includes support for the Jakarta Bean Validation specification, then it must also process Jakarta Bean Validation annotations when creating OpenAPI schemas. Such implementations must add the properties listed in the table below to the schema model when:
+
 * the annotation is applied to to an element for which a schema is generated and
 * the annotation and generated schema type are listed together in the table below and
 * the annotation has a `group` attribute which is empty or includes `jakarta.validation.groups.Default` and
@@ -603,27 +604,27 @@ Implementations are required to process Jakarta Bean Validation annotations and 
 | `@NotEmpty` | `object` | `minProperties = 1`
 | `@NotBlank` | `string` | `pattern = \S`
 | `@Size(min = a, max = b)` | `string`
-| `minLength = a` +
-`maxLenth = b`
+| `minLength = a +
+maxLenth = b`
 | `@Size(min = a, max = b)` | `array`
-| `minItems = a` +
-`maxItems = b`
+| `minItems = a +
+maxItems = b`
 | `@Size(min = a, max = b)` | `object`
-| `minProperties = a` +
-`maxProperties = b`
+| `minProperties = a +
+maxProperties = b`
 | `@DecimalMax(value = a)` | `number` or `integer` | `maximum = a`
-| `@DecimalMax(value = a, exclusive = false)` | `number` or `integer` | `maximum = a` +
-`exclusiveMaximum = true`
+| `@DecimalMax(value = a, exclusive = false)` | `number` or `integer` | `maximum = a +
+exclusiveMaximum = true`
 | `@DecimalMin(value = a)` | `number` or `integer` | `minimum = a`
-| `@DecimalMin(value = a, exclusive = false)` | `number` or `integer` | `minimum = a` +
-`exclusiveMinimum = true`
+| `@DecimalMin(value = a, exclusive = false)` | `number` or `integer` | `minimum = a +
+exclusiveMinimum = true`
 | `@Max(a)` | `number` or `integer` | `maximum = a`
 | `@Min(a)` | `number` or `integer` | `minimum = a`
-| `@Negative` | `number` or `integer` | `maximum = 0` +
-`exclusiveMaximum = true`
+| `@Negative` | `number` or `integer` | `maximum = 0 +
+exclusiveMaximum = true`
 | `@NegativeOrZero` | `number` or `integer` | `maximum = 0`
-| `@Positive` | `number` or `integer` | `minimum = 0` +
-`exclusiveMinimum = true`
+| `@Positive` | `number` or `integer` | `minimum = 0 +
+exclusiveMinimum = true`
 | `@PositiveOrZero` | `number` or `integer` | `minimum = 0`
 |===
 

--- a/tck/README.adoc
+++ b/tck/README.adoc
@@ -84,6 +84,25 @@ If you use Apache Maven, then the tests are run via the `maven-surefire-plugin` 
 ----
 Note: Be sure to set up your Arquillian.xml as required for your server under test.
 
+=== Testing platforms without Bean Validation
+
+Implementations which are part of runtimes which don't include Jakarta Bean Validation may exclude the relevant tests.
+
+[source, xml]
+----
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-surefire-plugin</artifactId>
+    <version>2.19.1</version>
+    <configuration>
+        <dependenciesToScan>
+            <dependency>org.eclipse.microprofile.openapi:microprofile-openapi-tck</dependency>
+        </dependenciesToScan>
+        <excludedGroups>bean-validation</excludedGroups>
+    </configuration>
+</plugin>
+----
+
 == Deploying Additional Implementation Artifacts
 TCK tests need some additional `jar` files to be located in `/lib` in the TCK runner project. The files are as follows: `commons-lang3-3.4.jar`, `commons-logging-1.2.jar`, `httpclient-4.5.2.jar`, `httpcore-4.4.4.jar`, `jackson-annotations-2.8.0.jar`, `jackson-core-2.8.6.jar`, `jackson-databind-2.8.6.jar`, `jackson-dataformat-yaml-2.8.6.jar` and `snakeyaml-1.17.jar`. These libraries are used by applications deployed to the server when running the TCK tests.
 

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/Groups.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/Groups.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.openapi.tck;
+
+public class Groups {
+
+    private Groups() {
+        // no instances
+    }
+
+    public static final String BEAN_VALIDATION = "bean-validation";
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/beanvalidation/BeanValidationDisabledTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/beanvalidation/BeanValidationDisabledTest.java
@@ -15,6 +15,7 @@
  */
 package org.eclipse.microprofile.openapi.tck.beanvalidation;
 
+import static org.eclipse.microprofile.openapi.tck.Groups.BEAN_VALIDATION;
 import static org.eclipse.microprofile.openapi.tck.beanvalidation.BeanValidationTest.assertProperty;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
@@ -43,7 +44,7 @@ public class BeanValidationDisabledTest extends AppTestBase {
                 .addAsManifestResource(config, "microprofile-config.properties");
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void beanValidationScanningDisabledTest(String format) {
         ValidatableResponse vr = callEndpoint(format);

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/beanvalidation/BeanValidationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/beanvalidation/BeanValidationTest.java
@@ -15,6 +15,7 @@
  */
 package org.eclipse.microprofile.openapi.tck.beanvalidation;
 
+import static org.eclipse.microprofile.openapi.tck.Groups.BEAN_VALIDATION;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
@@ -38,7 +39,7 @@ public class BeanValidationTest extends AppTestBase {
                 .addPackage(BeanValidationApp.class.getPackage());
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void notEmptyStringTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
@@ -46,7 +47,7 @@ public class BeanValidationTest extends AppTestBase {
         assertProperty(vr, "notEmptyString", hasEntry("type", "string"));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void notEmptyListTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
@@ -54,7 +55,7 @@ public class BeanValidationTest extends AppTestBase {
         assertProperty(vr, "notEmptyList", hasEntry("type", "array"));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void notEmptyMapTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
@@ -62,14 +63,14 @@ public class BeanValidationTest extends AppTestBase {
         assertProperty(vr, "notEmptyMap", hasEntry("type", "object"));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void notBlankStringTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "notBlankString", hasEntry("pattern", "\\S"));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void sizedStringTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
@@ -78,7 +79,7 @@ public class BeanValidationTest extends AppTestBase {
         assertProperty(vr, "sizedString", hasEntry("type", "string"));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void sizedListTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
@@ -87,7 +88,7 @@ public class BeanValidationTest extends AppTestBase {
         assertProperty(vr, "sizedList", hasEntry("type", "array"));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void sizedMapTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
@@ -96,7 +97,7 @@ public class BeanValidationTest extends AppTestBase {
         assertProperty(vr, "sizedMap", hasEntry("type", "object"));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void maxDecimalInclusiveTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
@@ -104,7 +105,7 @@ public class BeanValidationTest extends AppTestBase {
         assertProperty(vr, "maxDecimalInclusive", hasEntry("type", "number"));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void maxDecimalExclusiveTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
@@ -113,7 +114,7 @@ public class BeanValidationTest extends AppTestBase {
         assertProperty(vr, "maxDecimalExclusive", hasEntry("type", "number"));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void minDecimalInclusiveTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
@@ -121,7 +122,7 @@ public class BeanValidationTest extends AppTestBase {
         assertProperty(vr, "minDecimalInclusive", hasEntry("type", "number"));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void minDecimalExclusiveTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
@@ -130,21 +131,21 @@ public class BeanValidationTest extends AppTestBase {
         assertProperty(vr, "minDecimalExclusive", hasEntry("type", "number"));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void maxIntTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "maxInt", hasEntry("maximum", 5));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void minIntTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "minInt", hasEntry("minimum", 7));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void negativeIntTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
@@ -152,14 +153,14 @@ public class BeanValidationTest extends AppTestBase {
         assertProperty(vr, "negativeInt", hasEntry("exclusiveMaximum", true));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void negativeOrZeroIntTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "negativeOrZeroInt", hasEntry("maximum", 0));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void positiveIntTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
@@ -167,35 +168,35 @@ public class BeanValidationTest extends AppTestBase {
         assertProperty(vr, "positiveInt", hasEntry("exclusiveMinimum", true));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void positiveOrZeroIntTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "positiveOrZeroInt", hasEntry("minimum", 0));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void overridenBySchemaAnnotationTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "overridenBySchemaAnnotation", hasEntry("minLength", 6));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void nonDefaultGroupTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "nonDefaultGroup", not(hasKey("minLength")));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void defaultAndOtherGroupsTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "defaultAndOtherGroups", hasEntry("minLength", 1));
     }
 
-    @Test(dataProvider = "formatProvider")
+    @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
     @RunAsClient
     public void parameterTest(String format) {
         ValidatableResponse vr = callEndpoint(format);


### PR DESCRIPTION
Only require Bean Validations to be processed for creating the OpenAPI
document if support for Jakarta Bean Validation is actually present.

* Add spec wording
* Add Bean Validation tests to a group
* Update TCK readme to explain how to exclude the group

Also fix formatting error in the bean validation section of the spec,
bullet lists need to be preceded by a blank line.

Fixes #540