### PR TITLE
Make most archives not testable

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
@@ -43,7 +43,6 @@ import java.util.List;
 
 import org.hamcrest.collection.IsMapWithSize;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
@@ -51,21 +50,19 @@ import org.testng.annotations.Test;
 import io.restassured.response.ValidatableResponse;
 
 public class AirlinesAppTest extends AppTestBase {
-    @Deployment(name = "airlines")
+    @Deployment(name = "airlines", testable = false)
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "airlines.war")
                 .addPackages(true, "org.eclipse.microprofile.openapi.apps.airlines")
                 .addAsManifestResource("openapi.yaml", "openapi.yaml");
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testVersion(String type) {
         ValidatableResponse vr = callEndpoint(type);
         vr.body("openapi", startsWith("3.0."));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testInfo(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -75,7 +72,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("info.x-info", equalTo("test-info"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testContact(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -85,7 +81,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("info.contact.x-contact", equalTo("test-contact"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testLicense(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -94,7 +89,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("info.license.x-license", equalTo("test-license"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testExternalDocumentation(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -103,7 +97,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("externalDocs.x-external-docs", equalTo("test-external-docs"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testServer(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -181,7 +174,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(serverPath + ".variables", not(hasSize(greaterThan(0))));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testOperationAirlinesResource(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -189,7 +181,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/'.get.operationId", equalTo("getAirlines"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testOperationAvailabilityResource(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -198,7 +189,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/availability'.get.x-operation", equalTo("test-operation"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testRestClientNotPickedUp(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -206,7 +196,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/player/{playerId}'", equalTo(null));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testOperationBookingResource(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -228,7 +217,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/bookings/{id}'.delete.operationId", equalTo("deleteBookingById"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testOperationReviewResource(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -254,7 +242,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/reviews/{user}/{airlines}'.get.operationId", equalTo("getReviewByAirlineAndUser"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testOperationUserResource(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -299,7 +286,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/user/special'.post.parameters[0].schema", is(nullValue()));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testAPIResponse(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -324,7 +310,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/user/{username}'.patch.responses.'400'.description", equalTo("Invalid request"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testAPIResponses(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -346,7 +331,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/reviews/users/{user}'.get.responses.'500'.description", equalTo("Server error"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testParameter(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -440,7 +424,6 @@ public class AirlinesAppTest extends AppTestBase {
                 notNullValue());
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testExplode(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -451,7 +434,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(explode, equalTo(true));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testCallbackAnnotations(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -469,7 +451,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(endpoint + ".'bookingCallback'", hasKey("http://localhost:9080/airlines/bookings"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testCallbackOperationAnnotations(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -491,7 +472,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(endpoint + ".get.x-callback-operation", equalTo("test-callback-operation"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testRequestBodyAnnotations(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -523,7 +503,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(endpoint + ".required", equalTo(true));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSecurityRequirement(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -564,7 +543,6 @@ public class AirlinesAppTest extends AppTestBase {
                         hasEntry(equalTo("userBearerHttp"), empty()))));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSecuirtyRequirementInCallback(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -576,7 +554,6 @@ public class AirlinesAppTest extends AppTestBase {
                 anEmptyMap()));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSecuritySchemes(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -587,7 +564,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(s, hasKey("bookingSecurityScheme"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSecurityScheme(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -613,7 +589,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(reviewoauth2 + "description", equalTo("authentication needed to create and delete reviews"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testOAuthFlows(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -625,7 +600,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(t + ".x-oauth-flows", equalTo("test-oauth-flows"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testOAuthFlow(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -644,7 +618,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(client + "tokenUrl", equalTo("https://example.com/api/oauth/token"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testOAuthScope(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -655,7 +628,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(client + "scopes.'read:reviews'", equalTo("search for a review"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testEncodingRequestBody(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -667,7 +639,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(s + "x-encoding", equalTo("test-encoding"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testEncodingResponses(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -684,7 +655,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(t + "allowReserved", equalTo(true));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testLink(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -702,7 +672,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(k + "description", equalTo("get the review that was added"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testLinkParameter(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -716,7 +685,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(k + "parameters.reviewId", equalTo("$request.path.id"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSchema(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -747,7 +715,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(createSchema + ".uniqueItems", equalTo(true));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSchemaProperty(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -758,7 +725,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("components.schemas.User.properties.phone.x-schema-property", equalTo("test-schema-property"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSchemaPropertyValuesOverrideClassPropertyValues(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -767,7 +733,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("components.schemas.User.properties.phone.example", equalTo("123-456-7891"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testExampleObject(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -788,7 +753,6 @@ public class AirlinesAppTest extends AppTestBase {
                 equalTo("pat@example.com"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testContentExampleAttribute(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -796,7 +760,6 @@ public class AirlinesAppTest extends AppTestBase {
                 equalTo("Acme Air"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testTagDeclarations(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -817,7 +780,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(tagsPath + "Bookings" + "' }.x-tag", equalTo("test-tag"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testTagsInOperations(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -849,7 +811,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/'.get.tags", containsInAnyOrder("Airlines"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testComponents(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -878,7 +839,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("components.x-components", equalTo("test-components"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testHeaderInAPIResponse(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -903,7 +863,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(responseHeader2 + ".schema.type", equalTo("string"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testHeaderInEncoding(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -920,7 +879,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(testHeader + ".schema.type", equalTo("integer"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testRefHeaderInAPIResponse(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -931,7 +889,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(responseRefHeader + ".$ref", equalTo("#/components/headers/Request-Limit"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testRefHeaderInEncoding(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -943,7 +900,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(encodingRefHeader + ".$ref", equalTo("#/components/headers/Max-Rate"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testHeaderInComponents(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -957,7 +913,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(maxRate + ".x-header", equalTo("test-header"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testContentInAPIResponse(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -980,7 +935,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(content2 + ".'application/xml'.encoding.password", notNullValue());
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testContentInRequestBody(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -991,7 +945,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(contentJson + ".examples.booking.summary", equalTo("External booking example"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testContentInParameter(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -1002,7 +955,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(content + ".'*/*'.schema.type", equalTo("string"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testDefaultParameterRequirement(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -1026,7 +978,6 @@ public class AirlinesAppTest extends AppTestBase {
                 .or(hasEntry(equalTo("required"), equalTo(false))));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testStaticFileDefinitions(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -1077,7 +1028,6 @@ public class AirlinesAppTest extends AppTestBase {
                         .and(containsString("in further updates")));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testExtensionParsing(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -1091,7 +1041,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/'.get.'x-object-array-property'[1].name", equalTo("item-2"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testExceptionMappers(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -1109,7 +1058,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(rejectedReviewSchema + ".properties", hasKey("reason"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testAdditionalPropertiesDefault(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -1120,7 +1068,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(responseSchema, not(hasKey("additionalProperties")));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testAdditionalPropertiesFalse(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -1134,7 +1081,6 @@ public class AirlinesAppTest extends AppTestBase {
 
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testAdditionalPropertiesTrue(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -1148,7 +1094,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(airlineSchema, hasEntry(equalTo("additionalProperties"), equalTo(true)));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testAdditionalPropertiesTypeString(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -1161,7 +1106,6 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(flightSchema + ".additionalProperties.type", equalTo("string"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testOpenAPIDefinitionExtension(String type) {
         ValidatableResponse vr = callEndpoint(type);

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/FilterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/FilterTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
@@ -33,7 +32,7 @@ import org.testng.annotations.Test;
 import io.restassured.response.ValidatableResponse;
 
 public class FilterTest extends AppTestBase {
-    @Deployment(name = "airlinesFiltered")
+    @Deployment(name = "airlinesFiltered", testable = false)
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "airlinesFiltered.war")
                 .addPackages(true, "org.eclipse.microprofile.openapi.apps.airlines")
@@ -42,7 +41,6 @@ public class FilterTest extends AppTestBase {
                 .addAsManifestResource("microprofile-config-filter.properties", "microprofile-config.properties");
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testFilterServer(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -70,7 +68,6 @@ public class FilterTest extends AppTestBase {
         vr.body(serverPath + ".variables.protocol.enum", containsInAnyOrder("http", "https"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testFilterPathItemEnsureOrder(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -82,7 +79,6 @@ public class FilterTest extends AppTestBase {
                 equalTo("parent - Retrieve all bookings for current user"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testFilterPathItemAddOperation(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -91,7 +87,6 @@ public class FilterTest extends AppTestBase {
                 equalTo("filterPathItem - successfully put airlines"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testFilterOperation(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -101,7 +96,6 @@ public class FilterTest extends AppTestBase {
         vr.body("paths.'/bookings/{id}'.get.tags", containsInAnyOrder("Reservations", "parent - Bookings"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testFilterOpenAPI(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -109,7 +103,6 @@ public class FilterTest extends AppTestBase {
         vr.body("paths.'/bookings/{id}'.put.operationId", equalTo("updateBookingId"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testFilterParameter(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -125,7 +118,6 @@ public class FilterTest extends AppTestBase {
         vr.body(reviewParameters, hasSize(1));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testFilterRequestBody(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -135,7 +127,6 @@ public class FilterTest extends AppTestBase {
         vr.body(endpoint + ".content", notNullValue());
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testFilterSecurityScheme(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -145,7 +136,6 @@ public class FilterTest extends AppTestBase {
         vr.body(booking + "openIdConnectUrl", equalTo("http://openidconnect.com/testurl"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testFilterLink(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -154,7 +144,6 @@ public class FilterTest extends AppTestBase {
         vr.body(s + "description", equalTo("filterLink - The username corresponding to provided user id"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testFilterTag(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -163,7 +152,6 @@ public class FilterTest extends AppTestBase {
         vr.body(tagsPath + "user" + desc, equalTo("filterTag - Operations about user"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testFilterHeader(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -176,7 +164,6 @@ public class FilterTest extends AppTestBase {
         vr.body(maxRate + ".schema.type", equalTo("integer"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testFilterAPIResponse(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -186,7 +173,6 @@ public class FilterTest extends AppTestBase {
         vr.body(parentChild, equalTo("parent - id of the new review"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testFilterSchema(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -196,7 +182,6 @@ public class FilterTest extends AppTestBase {
 
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testFilterCallback(String type) {
         ValidatableResponse vr = callEndpoint(type);

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelReaderAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelReaderAppTest.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
@@ -40,7 +39,7 @@ import org.testng.annotations.Test;
 import io.restassured.response.ValidatableResponse;
 
 public class ModelReaderAppTest extends AppTestBase {
-    @Deployment(name = "airlinesModelReader")
+    @Deployment(name = "airlinesModelReader", testable = false)
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "airlinesReader.war")
                 .addPackages(true, "org.eclipse.microprofile.openapi.apps.airlines")
@@ -48,14 +47,12 @@ public class ModelReaderAppTest extends AppTestBase {
                 .addAsManifestResource("microprofile-reader.properties", "microprofile-config.properties");
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testVersion(String type) {
         ValidatableResponse vr = callEndpoint(type);
         vr.body("openapi", startsWith("3.0."));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testInfo(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -64,7 +61,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body("info.termsOfService", equalTo("http://airlinesratingapp.com/terms"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testContact(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -73,7 +69,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body("info.contact.email", equalTo("techsupport@airlinesratingapp.com"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testLicense(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -81,7 +76,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body("info.license.url", equalTo("http://www.apache.org/licenses/LICENSE-2.0.html"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testExternalDocumentation(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -89,7 +83,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body("externalDocs.url", containsString("README.md"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testServer(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -115,7 +108,6 @@ public class ModelReaderAppTest extends AppTestBase {
 
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testOperationAirlinesResource(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -123,7 +115,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body("paths.'/modelReader/airlines'.get.operationId", equalTo("getAirlines"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testOperationAvailabilityResource(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -131,7 +122,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body("paths.'/availability'.get.operationId", equalTo("getFlights"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testOperationBookingResource(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -144,7 +134,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body("paths.'/modelReader/bookings'.post.operationId", equalTo("createBooking"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testAPIResponse(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -154,7 +143,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body("paths.'/availability'.get.responses.'404'.description", equalTo("No available flights found"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testAvailabilityGetParameter(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -190,7 +178,6 @@ public class ModelReaderAppTest extends AppTestBase {
                 both(hasSize(1)).and(contains(0)));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSecurityRequirement(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -201,7 +188,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body("paths.'/bookings'.post.security.bookingSecurityScheme[0]", hasSize(2));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSecuritySchemes(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -209,7 +195,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body(s, hasKey("httpTestScheme"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSecurityScheme(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -219,7 +204,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body(http + "scheme", equalTo("testScheme"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSchema(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -233,7 +217,6 @@ public class ModelReaderAppTest extends AppTestBase {
                 equalTo("id of the new booking"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testExampleObject(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -243,7 +226,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body("components.examples.review.externalValue", equalTo("http://foo.bar/examples/review-example.json"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testTagDeclarations(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -262,7 +244,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body(tagsPath + "Retrieve Airlines" + desc, equalTo("method to retrieve all airlines"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testTagsInOperations(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -270,7 +251,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body("paths.'/modelReader/bookings'.get.tags", containsInAnyOrder("bookings"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testComponents(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -295,7 +275,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body("components.links.UserName", notNullValue());
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testHeaderInComponents(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -306,7 +285,6 @@ public class ModelReaderAppTest extends AppTestBase {
         vr.body(maxRate + ".allowEmptyValue", equalTo(true));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testContentInAPIResponse(String type) {
         ValidatableResponse vr = callEndpoint(type);

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassBase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanClassBase.java
@@ -20,7 +20,6 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.testng.annotations.Test;
 
 import io.restassured.response.ValidatableResponse;
@@ -31,7 +30,6 @@ import io.restassured.response.ValidatableResponse;
 public abstract class OASConfigScanClassBase extends AppTestBase {
     private ValidatableResponse vr;
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testScanClass(String type) throws InterruptedException {
         vr = callEndpoint(type);

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanDisableTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigScanDisableTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
@@ -31,14 +30,13 @@ import io.restassured.response.ValidatableResponse;
 public class OASConfigScanDisableTest extends AppTestBase {
     private ValidatableResponse vr;
 
-    @Deployment(name = "airlines")
+    @Deployment(name = "airlines", testable = false)
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "airlines.war")
                 .addPackages(true, "org.eclipse.microprofile.openapi.apps.airlines")
                 .addAsManifestResource("scan-disable-microprofile-config.properties", "microprofile-config.properties");
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testScanDisable(String type) throws InterruptedException {
         vr = callEndpoint(type);

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigSchemaTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigSchemaTest.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import org.hamcrest.Matcher;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
@@ -34,7 +33,7 @@ import io.restassured.response.ValidatableResponse;
 
 public class OASConfigSchemaTest extends AppTestBase {
 
-    @Deployment(name = "petstore")
+    @Deployment(name = "petstore", testable = false)
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "petstore.war")
                 .addPackages(true, "org.eclipse.microprofile.openapi.apps.petstore")
@@ -42,7 +41,6 @@ public class OASConfigSchemaTest extends AppTestBase {
                         "classes/META-INF/microprofile-config.properties");
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSchemaConfigApplied(String type) {
         ValidatableResponse vr = callEndpoint(type);

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigServersTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigServersTest.java
@@ -18,7 +18,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
@@ -28,14 +27,13 @@ import io.restassured.response.ValidatableResponse;
 public class OASConfigServersTest extends AppTestBase {
     private ValidatableResponse vr;
 
-    @Deployment(name = "airlines")
+    @Deployment(name = "airlines", testable = false)
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "airlines.war")
                 .addPackages(true, "org.eclipse.microprofile.openapi.apps.airlines")
                 .addAsManifestResource("server-microprofile-config.properties", "microprofile-config.properties");
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testServer(String type) throws InterruptedException {
         vr = callEndpoint(type);

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigWebInfTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASConfigWebInfTest.java
@@ -22,7 +22,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 public class OASConfigWebInfTest extends OASConfigScanClassBase {
 
-    @Deployment(name = "airlinesWebInf")
+    @Deployment(name = "airlinesWebInf", testable = false)
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "airlinesWebInf.war")
                 .addPackages(true, "org.eclipse.microprofile.openapi.apps.airlines")

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASScanConfigTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASScanConfigTests.java
@@ -26,7 +26,6 @@ import org.eclipse.microprofile.openapi.apps.scanconfig.a.b.c.CResource;
 import org.eclipse.microprofile.openapi.apps.scanconfig.x.y.YResource;
 import org.eclipse.microprofile.openapi.tck.utils.ConfigAsset;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
@@ -37,14 +36,13 @@ public class OASScanConfigTests {
 
     public static class ScanConfigIncludeOnly extends AppTestBase {
 
-        @Deployment
+        @Deployment(testable = false)
         public static WebArchive deployment() {
             ConfigAsset config = new ConfigAsset()
                     .put(OASConfig.SCAN_CLASSES, BResource.class.getName());
             return scanConfigApp("scanConfigIncludeOnly.war", config);
         }
 
-        @RunAsClient
         @Test(dataProvider = "formatProvider")
         public void testIncludeOnly(String type) {
             assertPaths(callEndpoint(type), "/b");
@@ -53,14 +51,13 @@ public class OASScanConfigTests {
 
     public static class ScanConfigIncludeMultiple extends AppTestBase {
 
-        @Deployment
+        @Deployment(testable = false)
         public static WebArchive deployment() {
             ConfigAsset config = new ConfigAsset()
                     .put(OASConfig.SCAN_CLASSES, BResource.class.getName(), YResource.class.getName());
             return scanConfigApp("scanConfigIncludeMultiple.war", config);
         }
 
-        @RunAsClient
         @Test(dataProvider = "formatProvider")
         public void testIncludeMultiple(String type) {
             assertPaths(callEndpoint(type), "/b", "/y");
@@ -69,14 +66,13 @@ public class OASScanConfigTests {
 
     public static class ScanConfigPackageIncludeOnly extends AppTestBase {
 
-        @Deployment
+        @Deployment(testable = false)
         public static WebArchive deployment() {
             ConfigAsset config = new ConfigAsset()
                     .put(OASConfig.SCAN_PACKAGES, BResource.class.getPackage().getName());
             return scanConfigApp("scanConfigPackageIncludeOnly.war", config);
         }
 
-        @RunAsClient
         @Test(dataProvider = "formatProvider")
         public void testPackageIncludeOnly(String type) {
             assertPaths(callEndpoint(type), "/b", "/c");
@@ -85,7 +81,7 @@ public class OASScanConfigTests {
 
     public static class ScanConfigPackageIncludeMultiple extends AppTestBase {
 
-        @Deployment
+        @Deployment(testable = false)
         public static WebArchive deployment() {
             ConfigAsset config = new ConfigAsset()
                     .put(OASConfig.SCAN_PACKAGES, BResource.class.getPackage().getName(),
@@ -93,7 +89,6 @@ public class OASScanConfigTests {
             return scanConfigApp("scanConfigPackageIncludeMultiple.war", config);
         }
 
-        @RunAsClient
         @Test(dataProvider = "formatProvider")
         public void testPackageIncludeMultiple(String type) {
             assertPaths(callEndpoint(type), "/b", "/c", "/y");
@@ -102,14 +97,13 @@ public class OASScanConfigTests {
 
     public static class ScanConfigExcludeOnly extends AppTestBase {
 
-        @Deployment
+        @Deployment(testable = false)
         public static WebArchive deployment() {
             ConfigAsset config = new ConfigAsset()
                     .put(OASConfig.SCAN_EXCLUDE_CLASSES, BResource.class.getName());
             return scanConfigApp("scanConfigExcludeOnly.war", config);
         }
 
-        @RunAsClient
         @Test(dataProvider = "formatProvider")
         public void testExcludeOnly(String type) {
             assertPaths(callEndpoint(type), "/a", "/c", "/x", "/y");
@@ -118,14 +112,13 @@ public class OASScanConfigTests {
 
     public static class ScanConfigExcludeMultiple extends AppTestBase {
 
-        @Deployment
+        @Deployment(testable = false)
         public static WebArchive deployment() {
             ConfigAsset config = new ConfigAsset()
                     .put(OASConfig.SCAN_EXCLUDE_CLASSES, BResource.class.getName(), YResource.class.getName());
             return scanConfigApp("scanConfigExcludeMultiple.war", config);
         }
 
-        @RunAsClient
         @Test(dataProvider = "formatProvider")
         public void testExcludeMultiple(String type) {
             assertPaths(callEndpoint(type), "/a", "/c", "/x");
@@ -134,14 +127,13 @@ public class OASScanConfigTests {
 
     public static class ScanConfigPackageExcludeOnly extends AppTestBase {
 
-        @Deployment
+        @Deployment(testable = false)
         public static WebArchive deployment() {
             ConfigAsset config = new ConfigAsset()
                     .put(OASConfig.SCAN_EXCLUDE_PACKAGES, BResource.class.getPackage().getName());
             return scanConfigApp("scanConfigPackageExcludeOnly.war", config);
         }
 
-        @RunAsClient
         @Test(dataProvider = "formatProvider")
         public void testPackageExcludeOnly(String type) {
             assertPaths(callEndpoint(type), "/a", "/x", "/y");
@@ -150,7 +142,7 @@ public class OASScanConfigTests {
 
     public static class ScanConfigPackageExcludeMultiple extends AppTestBase {
 
-        @Deployment
+        @Deployment(testable = false)
         public static WebArchive deployment() {
             ConfigAsset config = new ConfigAsset()
                     .put(OASConfig.SCAN_EXCLUDE_PACKAGES, BResource.class.getPackage().getName(),
@@ -158,7 +150,6 @@ public class OASScanConfigTests {
             return scanConfigApp("scanConfigPackageExcludeMultiple.war", config);
         }
 
-        @RunAsClient
         @Test(dataProvider = "formatProvider")
         public void testPackageExcludeMultiple(String type) {
             assertPaths(callEndpoint(type), "/a", "/x");
@@ -167,7 +158,7 @@ public class OASScanConfigTests {
 
     public static class ScanConfigPackageIncludesAroundExcludes extends AppTestBase {
 
-        @Deployment
+        @Deployment(testable = false)
         public static WebArchive deployment() {
             ConfigAsset config = new ConfigAsset()
                     .put(OASConfig.SCAN_PACKAGES, AResource.class.getPackage().getName(),
@@ -176,7 +167,6 @@ public class OASScanConfigTests {
             return scanConfigApp("scanConfigPackageIncludesAroundExcludes.war", config);
         }
 
-        @RunAsClient
         @Test(dataProvider = "formatProvider")
         public void testPackageIncludesAroundExcludes(String type) {
             assertPaths(callEndpoint(type), "/a", "/c");
@@ -185,7 +175,7 @@ public class OASScanConfigTests {
 
     public static class ScanConfigPackageExcludesAroundInclude extends AppTestBase {
 
-        @Deployment
+        @Deployment(testable = false)
         public static WebArchive deployment() {
             ConfigAsset config = new ConfigAsset()
                     .put(OASConfig.SCAN_PACKAGES, BResource.class.getPackage().getName())
@@ -194,7 +184,6 @@ public class OASScanConfigTests {
             return scanConfigApp("scanConfigPackageExcludesAroundInclude.war", config);
         }
 
-        @RunAsClient
         @Test(dataProvider = "formatProvider")
         public void testPackageExcludesAroundInclude(String type) {
             assertPaths(callEndpoint(type), "/b");
@@ -203,7 +192,7 @@ public class OASScanConfigTests {
 
     public static class ScanConfigPackageExcludeClassInclude extends AppTestBase {
 
-        @Deployment
+        @Deployment(testable = false)
         public static WebArchive deployment() {
             ConfigAsset config = new ConfigAsset()
                     .put(OASConfig.SCAN_CLASSES, AResource.class.getName())
@@ -211,7 +200,6 @@ public class OASScanConfigTests {
             return scanConfigApp("scanConfigPackageExcludeClassInclude.war", config);
         }
 
-        @RunAsClient
         @Test(dataProvider = "formatProvider")
         public void testPackageExcludeClassInclude(String type) {
             assertPaths(callEndpoint(type), "/a");
@@ -220,7 +208,7 @@ public class OASScanConfigTests {
 
     public static class ScanConfigPackageIncludeClassExclude extends AppTestBase {
 
-        @Deployment
+        @Deployment(testable = false)
         public static WebArchive deployment() {
             ConfigAsset config = new ConfigAsset()
                     .put(OASConfig.SCAN_PACKAGES, AResource.class.getPackage().getName())
@@ -228,7 +216,6 @@ public class OASScanConfigTests {
             return scanConfigApp("scanConfigPackageIncludeClassExclude.war", config);
         }
 
-        @RunAsClient
         @Test(dataProvider = "formatProvider")
         public void testPackageIncludeClassExclude(String type) {
             assertPaths(callEndpoint(type), "/b", "/c");
@@ -237,7 +224,7 @@ public class OASScanConfigTests {
 
     public static class ScanConfigPartialPackage extends AppTestBase {
 
-        @Deployment
+        @Deployment(testable = false)
         public static WebArchive deployment() {
             ConfigAsset config = new ConfigAsset()
                     .put(OASConfig.SCAN_PACKAGES, "a.b.c");
@@ -245,7 +232,6 @@ public class OASScanConfigTests {
             return scanConfigApp("scanConfigPartialPackage.war", config);
         }
 
-        @RunAsClient
         @Test(dataProvider = "formatProvider")
         public void testPartialPackage(String type) {
             assertPaths(callEndpoint(type)); // assert no paths

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/PetStoreAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/PetStoreAppTest.java
@@ -33,7 +33,6 @@ import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 import static org.testng.Assert.assertNotNull;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
@@ -41,13 +40,12 @@ import org.testng.annotations.Test;
 import io.restassured.response.ValidatableResponse;
 
 public class PetStoreAppTest extends AppTestBase {
-    @Deployment(name = "petstore")
+    @Deployment(name = "petstore", testable = false)
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "petstore.war")
                 .addPackages(true, "org.eclipse.microprofile.openapi.apps.petstore");
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSchema(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -79,7 +77,6 @@ public class PetStoreAppTest extends AppTestBase {
 
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSecurityRequirement(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -105,7 +102,6 @@ public class PetStoreAppTest extends AppTestBase {
         vr.body("paths.'/user'.post.security.find { it.userBearerHttp != null }.userBearerHttp", empty());
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSecuritySchemes(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -120,7 +116,6 @@ public class PetStoreAppTest extends AppTestBase {
         vr.body(s, hasKey("petsHttp"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testSecurityScheme(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -174,7 +169,6 @@ public class PetStoreAppTest extends AppTestBase {
                 equalTo("https://petstoreauth.com:4433/oidc/petstore/oidcprovider/authorize"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testOAuthFlows(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -183,7 +177,6 @@ public class PetStoreAppTest extends AppTestBase {
         vr.body(t, hasKey("authorizationCode"));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testOAuthFlow(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -195,7 +188,6 @@ public class PetStoreAppTest extends AppTestBase {
         vr.body(authCode + "tokenUrl", equalTo("https://example.com/api/oauth/token"));
     }
 
-    @RunAsClient
     @Test
     public void testDefaultResponseType() {
         given()
@@ -208,7 +200,6 @@ public class PetStoreAppTest extends AppTestBase {
                 .body("openapi", startsWith("3.0."));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testRequestBodySchema(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -231,7 +222,6 @@ public class PetStoreAppTest extends AppTestBase {
                         hasEntry(equalTo("properties"), notNullValue())));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testAPIResponseSchema(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -255,7 +245,6 @@ public class PetStoreAppTest extends AppTestBase {
                         hasEntry(equalTo("properties"), notNullValue())));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testAPIResponseSchemaDefaultResponseCode(String type) {
         ValidatableResponse vr = callEndpoint(type);
@@ -288,7 +277,6 @@ public class PetStoreAppTest extends AppTestBase {
                         hasEntry(equalTo("properties"), notNullValue())));
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testExtensionPlacement(String type) {
         ValidatableResponse vr = callEndpoint(type);

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/StaticDocumentTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/StaticDocumentTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
@@ -38,13 +37,12 @@ import io.restassured.response.ValidatableResponse;
  */
 public class StaticDocumentTest extends AppTestBase {
 
-    @Deployment(name = "static")
+    @Deployment(name = "static", testable = false)
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "static.war")
                 .addAsManifestResource("simpleapi.yaml", "openapi.yaml");
     }
 
-    @RunAsClient
     @Test(dataProvider = "formatProvider")
     public void testStaticDocument(String type) {
         ValidatableResponse vr = callEndpoint(type);

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/beanvalidation/BeanValidationDisabledTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/beanvalidation/BeanValidationDisabledTest.java
@@ -24,7 +24,6 @@ import org.eclipse.microprofile.openapi.OASConfig;
 import org.eclipse.microprofile.openapi.apps.beanvalidation.BeanValidationApp;
 import org.eclipse.microprofile.openapi.tck.AppTestBase;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -35,7 +34,7 @@ import io.restassured.response.ValidatableResponse;
 
 public class BeanValidationDisabledTest extends AppTestBase {
 
-    @Deployment
+    @Deployment(testable = false)
     public static WebArchive buildApp() {
         Asset config = new StringAsset(OASConfig.SCAN_BEANVALIDATION + "=false");
 
@@ -45,7 +44,6 @@ public class BeanValidationDisabledTest extends AppTestBase {
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void beanValidationScanningDisabledTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "notEmptyString", not(hasKey("minLength")));

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/beanvalidation/BeanValidationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/beanvalidation/BeanValidationTest.java
@@ -24,7 +24,6 @@ import org.eclipse.microprofile.openapi.apps.beanvalidation.BeanValidationApp;
 import org.eclipse.microprofile.openapi.tck.AppTestBase;
 import org.hamcrest.Matcher;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
@@ -33,14 +32,13 @@ import io.restassured.response.ValidatableResponse;
 
 public class BeanValidationTest extends AppTestBase {
 
-    @Deployment
+    @Deployment(testable = false)
     public static WebArchive buildApp() {
         return ShrinkWrap.create(WebArchive.class, "beanValidation.war")
                 .addPackage(BeanValidationApp.class.getPackage());
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void notEmptyStringTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "notEmptyString", hasEntry("minLength", 1));
@@ -48,7 +46,6 @@ public class BeanValidationTest extends AppTestBase {
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void notEmptyListTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "notEmptyList", hasEntry("minItems", 1));
@@ -56,7 +53,6 @@ public class BeanValidationTest extends AppTestBase {
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void notEmptyMapTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "notEmptyMap", hasEntry("minProperties", 1));
@@ -64,14 +60,12 @@ public class BeanValidationTest extends AppTestBase {
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void notBlankStringTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "notBlankString", hasEntry("pattern", "\\S"));
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void sizedStringTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "sizedString", hasEntry("minLength", 2));
@@ -80,7 +74,6 @@ public class BeanValidationTest extends AppTestBase {
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void sizedListTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "sizedList", hasEntry("minItems", 1));
@@ -89,7 +82,6 @@ public class BeanValidationTest extends AppTestBase {
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void sizedMapTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "sizedMap", hasEntry("minProperties", 3));
@@ -98,7 +90,6 @@ public class BeanValidationTest extends AppTestBase {
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void maxDecimalInclusiveTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "maxDecimalInclusive", hasEntry("maximum", 1.5f));
@@ -106,7 +97,6 @@ public class BeanValidationTest extends AppTestBase {
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void maxDecimalExclusiveTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "maxDecimalExclusive", hasEntry("maximum", 1.5f));
@@ -115,7 +105,6 @@ public class BeanValidationTest extends AppTestBase {
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void minDecimalInclusiveTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "minDecimalInclusive", hasEntry("minimum", 3.25f));
@@ -123,7 +112,6 @@ public class BeanValidationTest extends AppTestBase {
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void minDecimalExclusiveTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "minDecimalExclusive", hasEntry("minimum", 3.25f));
@@ -132,21 +120,18 @@ public class BeanValidationTest extends AppTestBase {
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void maxIntTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "maxInt", hasEntry("maximum", 5));
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void minIntTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "minInt", hasEntry("minimum", 7));
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void negativeIntTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "negativeInt", hasEntry("maximum", 0));
@@ -154,14 +139,12 @@ public class BeanValidationTest extends AppTestBase {
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void negativeOrZeroIntTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "negativeOrZeroInt", hasEntry("maximum", 0));
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void positiveIntTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "positiveInt", hasEntry("minimum", 0));
@@ -169,35 +152,30 @@ public class BeanValidationTest extends AppTestBase {
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void positiveOrZeroIntTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "positiveOrZeroInt", hasEntry("minimum", 0));
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void overridenBySchemaAnnotationTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "overridenBySchemaAnnotation", hasEntry("minLength", 6));
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void nonDefaultGroupTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "nonDefaultGroup", not(hasKey("minLength")));
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void defaultAndOtherGroupsTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         assertProperty(vr, "defaultAndOtherGroups", hasEntry("minLength", 1));
     }
 
     @Test(dataProvider = "formatProvider", groups = BEAN_VALIDATION)
-    @RunAsClient
     public void parameterTest(String format) {
         ValidatableResponse vr = callEndpoint(format);
         String schemaPath = dereference(vr, "paths.'/parameter/{test}'.post.parameters[0]", "schema");


### PR DESCRIPTION
A "testable" archive is one that arquillian adds extra framework code to
in order to run tests within the server runtime environment.

Most of the MP OpenAPI test classes don't include any tests which run on
the server side, they deploy an app and then query the /openapi endpoint
from the client side.

In addition, it causes problems when using the new arquillian REST 3.0
protocol. When using this protocol, an additional REST resource is
deployed within testable deployments which is scanned and added to the
openapi documentation which causes some of the tests to fail.

Fixes #546 