### PR TITLE
TCK: fix several incorrectly used annotations and associated tests

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/JAXRSApp.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/JAXRSApp.java
@@ -71,6 +71,7 @@ import jakarta.ws.rs.core.MediaType;
                                                          extensions = @Extension(name = "x-external-docs",
                                                                                  value = "test-external-docs")),
                    info = @Info(title = "AirlinesRatingApp API", version = "1.0",
+                                description = "APIs for booking and managing air flights",
                                 termsOfService = "http://airlinesratingapp.com/terms",
                                 contact = @Contact(name = "AirlinesRatingApp API Support",
                                                    url = "http://exampleurl.com/contact",
@@ -208,10 +209,6 @@ import jakarta.ws.rs.core.MediaType;
 @SecurityScheme(securitySchemeName = "testScheme2",
                 type = SecuritySchemeType.HTTP,
                 scheme = "Basic")
-@Schema(name = "AirlinesRatingApp API",
-        description = "APIs for booking and managing air flights",
-        externalDocs = @ExternalDocumentation(description = "For more information, see the link.",
-                                              url = "http://exampleurl.com/schema"))
 public class JAXRSApp extends Application {
     @Override
     public Set<Object> getSingletons() {

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/model/User.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/model/User.java
@@ -33,7 +33,7 @@ public class User {
     @Schema(required = true, example = "Smith")
     private String lastName;
 
-    @Schema(required = true, example = "M")
+    @Schema(required = true, example = "Male")
     private Gender gender;
 
     @Schema(required = true, example = "37")

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/AirlinesResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/AirlinesResource.java
@@ -37,7 +37,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 
 @Path("")
-@Schema(name = "Airline Booking API")
 @Tags(value = @Tag(name = "Airlines", description = "All the airlines methods"))
 @Callback(name = "availabilityCallback", callbackUrlExpression = "http://localhost:9080/oas3-airlines/availability",
           operations = @CallbackOperation(method = "get", summary = "Retrieve available flights.", responses = {

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/ReviewResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/ReviewResource.java
@@ -161,10 +161,10 @@ public class ReviewResource {
     @Produces("application/json")
     public Response getReviewByUser(
             @Parameter(name = "user", description = "username of the user for the reviews", in = ParameterIn.PATH,
-                       content = @Content(examples = @ExampleObject(name = "example", value = "bsmith")), examples = {
+                       content = @Content(examples = {
                                @ExampleObject(name = "example1", value = "bsmith"),
                                @ExampleObject(name = "example2",
-                                              value = "pat@example.com")}) @PathParam("user") String user,
+                                              value = "pat@example.com")})) @PathParam("user") String user,
             @QueryParam("minRating") Integer minRating,
             @HeaderParam("If-Match") String ifMatch,
             @CookieParam("trackme") String trackme) {
@@ -201,8 +201,7 @@ public class ReviewResource {
     @Operation(operationId = "getReviewByAirline", summary = "Get all reviews by airlines")
     @Parameter(name = "airline", description = "name of the airlines for the reviews", required = true,
                in = ParameterIn.PATH,
-               content = @Content(examples = @ExampleObject(name = "example", value = "Acme Air")),
-               example = "Acme Air")
+               content = @Content(examples = @ExampleObject(name = "example", value = "Acme Air")))
     @APIResponse(responseCode = "200", description = "Review(s) retrieved",
                  content = @Content(schema = @Schema(implementation = Review.class)))
     @APIResponse(responseCode = "404", description = "Review(s) not found")

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/UserResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/UserResource.java
@@ -152,10 +152,7 @@ public class UserResource {
                          content = @Content(mediaType = "application/json",
                                             schema = @Schema(type = SchemaType.ARRAY, implementation = User.class,
                                                              nullable = true, writeOnly = true, minItems = 2,
-                                                             maxItems = 20, uniqueItems = true),
-                                            encoding = @Encoding(name = "firstName", contentType = "text/plain",
-                                                                 style = "form", allowReserved = true,
-                                                                 explode = true))) User[] users) {
+                                                             maxItems = 20, uniqueItems = true))) User[] users) {
         for (User user : users) {
             userData.addUser(user);
         }
@@ -279,7 +276,7 @@ public class UserResource {
                                parameters = @LinkParameter(name = "userId", expression = "$request.path.id"),
                                extensions = @Extension(name = "x-link", value = "test-link")),
                          @Link(name = "Review", description = "The reviews provided by user",
-                               operationRef = "/db/reviews/{userName}",
+                               operationRef = "#/paths/~1reviews~1users~1{user}/get",
                                parameters = @LinkParameter(name = "path.userName",
                                                            expression = "$response.body#userName"),
                                requestBody = "$request.path.id", server = @Server(url = "http://example.com"))

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/PetStoreApp.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/PetStoreApp.java
@@ -22,6 +22,7 @@ import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
 import org.eclipse.microprofile.openapi.annotations.info.Contact;
 import org.eclipse.microprofile.openapi.annotations.info.Info;
 import org.eclipse.microprofile.openapi.annotations.info.License;
+import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.apps.petstore.model.Lizard;
@@ -48,9 +49,20 @@ import jakarta.ws.rs.core.Application;
                                 externalDocs = @ExternalDocumentation(url = "http://swagger.io",
                                                                       description = "Find out more about our store"))
                    },
-                   components = @Components(schemas = {
-                           @Schema(name = "Lizard", implementation = Lizard.class)
-                   }))
+                   components = @Components(
+                                            schemas = {
+                                                    @Schema(name = "Lizard", implementation = Lizard.class)
+                                            },
+                                            examples = {
+                                                    @ExampleObject(name = "pet-example", value = "{"
+                                                            + "  \"id\": 4,"
+                                                            + "  \"name\": \"Dog 1\","
+                                                            + "  \"category\": { \"id\": 1, \"name\": \"Dogs\" },"
+                                                            + "  \"photoUrls\": [ \"url1\", \"url2\" ],"
+                                                            + "  \"tags\": [ \"tag1\", \"tag2\" ],"
+                                                            + "  \"status\": \"available\""
+                                                            + "}")
+                                            }))
 @Schema(externalDocs = @ExternalDocumentation(url = "http://swagger.io", description = "Find out more about our store"))
 public class PetStoreApp extends Application {
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/resource/PetResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/resource/PetResource.java
@@ -19,6 +19,7 @@ import org.eclipse.microprofile.openapi.annotations.ExternalDocumentation;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.callbacks.Callback;
 import org.eclipse.microprofile.openapi.annotations.callbacks.CallbackOperation;
+import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeIn;
 import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
@@ -62,16 +63,17 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 
 @Path("/pet")
-@Schema(name = "pet", description = "Operations on pets resource")
 @SecuritySchemes(value = {
         @SecurityScheme(securitySchemeName = "petsApiKey", type = SecuritySchemeType.APIKEY,
                         description = "authentication needed to create a new pet profile for the store",
                         apiKeyName = "createPetProfile", in = SecuritySchemeIn.HEADER),
         @SecurityScheme(securitySchemeName = "petsOAuth2", type = SecuritySchemeType.OAUTH2,
                         description = "authentication needed to delete a pet profile",
-                        flows = @OAuthFlows(implicit = @OAuthFlow(authorizationUrl = "https://example.com/api/oauth/dialog"),
+                        flows = @OAuthFlows(implicit = @OAuthFlow(authorizationUrl = "https://example.com/api/oauth/dialog",
+                                                                  scopes = {}),
                                             authorizationCode = @OAuthFlow(authorizationUrl = "https://example.com/api/oauth/dialog",
-                                                                           tokenUrl = "https://example.com/api/oauth/token"))),
+                                                                           tokenUrl = "https://example.com/api/oauth/token",
+                                                                           scopes = {}))),
         @SecurityScheme(securitySchemeName = "petsHttp", type = SecuritySchemeType.HTTP,
                         description = "authentication needed to update an exsiting record of a pet in the store",
                         scheme = "bearer", bearerFormat = "jwt")
@@ -87,6 +89,7 @@ public class PetResource {
                          content = @Content(mediaType = "none")),
             @APIResponse(responseCode = "404", description = "Pet not found", content = @Content(mediaType = "none")),
             @APIResponse(responseCode = "200",
+                         description = "Pet found",
                          content = @Content(mediaType = "application/json",
                                             schema = @Schema(type = SchemaType.OBJECT, implementation = Pet.class,
                                                              oneOf = {
@@ -150,7 +153,7 @@ public class PetResource {
     public Response deletePet(
             @Parameter(name = "apiKey", description = "authentication key to access this method",
                        schema = @Schema(type = SchemaType.STRING, implementation = String.class, maxLength = 256,
-                                        minLength = 32)) @HeaderParam("api_key") String apiKey,
+                                        minLength = 32)) @HeaderParam("apiKey") String apiKey,
             @Parameter(name = "petId", description = "ID of pet that needs to be fetched", required = true,
                        schema = @Schema(implementation = Long.class, maximum = "10",
                                         minimum = "1")) @PathParam("petId") Long petId) {
@@ -170,7 +173,7 @@ public class PetResource {
                                     schema = @Schema(implementation = ApiResponse.class)))
     @RequestBody(name = "pet",
                  content = @Content(mediaType = "application/json", schema = @Schema(implementation = Pet.class),
-                                    examples = @ExampleObject(ref = "http://example.org/petapi-examples/openapi.json#/components/examples/pet-example")),
+                                    examples = @ExampleObject(ref = "#/components/examples/pet-example")),
                  required = true, description = "example of a new pet to add")
     @Operation(summary = "Add pet to store", description = "Add a new pet to the store")
     public Response addPet(Pet pet) {
@@ -191,8 +194,9 @@ public class PetResource {
     })
     @Operation(summary = "Update an existing pet", description = "Update an existing pet with the given new attributes")
     public Response updatePet(
-            @Parameter(name = "petAttribute", description = "Attribute to update existing pet record", required = true,
-                       schema = @Schema(implementation = Pet.class)) Pet pet) {
+            @RequestBody(name = "petAttribute", description = "Attribute to update existing pet record",
+                         required = true,
+                         content = @Content(schema = @Schema(implementation = Pet.class))) Pet pet) {
         Pet updatedPet = petData.addPet(pet);
         return Response.ok().entity(updatedPet).build();
     }
@@ -200,7 +204,7 @@ public class PetResource {
     @GET
     @Path("/findByStatus")
     @APIResponse(responseCode = "400", description = "Invalid status value", content = @Content(mediaType = "none"))
-    @APIResponse(responseCode = "200",
+    @APIResponse(responseCode = "200", description = "Pets found with matching status",
                  content = @Content(mediaType = "application/json",
                                     schema = @Schema(type = SchemaType.ARRAY, implementation = Pet.class)))
     @Operation(summary = "Finds Pets by status",
@@ -208,16 +212,19 @@ public class PetResource {
     @Extension(name = "x-mp-method1", value = "true")
     @Extensions({@Extension(name = "x-mp-method2", value = "true"), @Extension(value = "false", name = "x-mp-method3")})
     public Response findPetsByStatus(
-            @Parameter(name = "status", description = "Status values that need to be considered for filter",
-                       required = true, schema = @Schema(implementation = String.class), content = {
-                               @Content(examples = {
-                                       @ExampleObject(name = "Available", value = "available",
-                                                      summary = "Retrieves all the pets that are available"),
-                                       @ExampleObject(name = "Pending", value = "pending",
-                                                      summary = "Retrieves all the pets that are pending to be sold"),
-                                       @ExampleObject(name = "Sold", value = "sold",
-                                                      summary = "Retrieves all the pets that are sold")
-                               })
+            @Parameter(name = "status", in = ParameterIn.QUERY,
+                       description = "Status values that need to be considered for filter",
+                       required = true, content = {
+                               @Content(
+                                        schema = @Schema(implementation = String.class),
+                                        examples = {
+                                                @ExampleObject(name = "Available", value = "available",
+                                                               summary = "Retrieves all the pets that are available"),
+                                                @ExampleObject(name = "Pending", value = "pending",
+                                                               summary = "Retrieves all the pets that are pending to be sold"),
+                                                @ExampleObject(name = "Sold", value = "sold",
+                                                               summary = "Retrieves all the pets that are sold")
+                                        })
                        }, allowEmptyValue = true) @Extension(name = "x-mp-parm1", value = "true") String status) {
         return Response.ok(petData.findPetByStatus(status)).build();
     }
@@ -233,6 +240,7 @@ public class PetResource {
                                                                    description = "Invalid tag value",
                                                                    content = @Content(mediaType = "none")),
                                                       @APIResponse(responseCode = "200",
+                                                                   description = "Pet callback successfully processed",
                                                                    content = @Content(mediaType = "application/json",
                                                                                       schema = @Schema(type = SchemaType.ARRAY,
                                                                                                        implementation = Pet.class)))

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/resource/PetStoreResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/resource/PetStoreResource.java
@@ -21,6 +21,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
@@ -43,7 +44,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 
 @Path("/store")
-@Schema(name = "/store")
 @Produces({"application/json", "application/xml"})
 @SecuritySchemes(value = {
         @SecurityScheme(securitySchemeName = "storeOpenIdConnect", type = SecuritySchemeType.OPENIDCONNECT,
@@ -94,7 +94,7 @@ public class PetStoreResource {
                          BadOrder.class}, discriminatorProperty = "id",
                                                      discriminatorMapping = @DiscriminatorMapping(value = "0",
                                                                                                   schema = BadOrder.class))))
-    @APIResponse(responseCode = "900", description = "Invalid",
+    @APIResponse(responseCode = "599", description = "Invalid",
                  content = @Content(schema = @Schema(implementation = Order.class, hidden = true)))
     public Response getOrderById(
             @Parameter(name = "orderId", description = "ID of pet that needs to be fetched",
@@ -115,7 +115,7 @@ public class PetStoreResource {
     @APIResponse(responseCode = "200", description = "successful operation")
     @APIResponse(responseCode = "400", description = "Invalid Order")
     public Order placeOrder(
-            @Parameter(description = "order placed for purchasing the pet", required = true) Order order) {
+            @RequestBody(description = "order placed for purchasing the pet", required = true) Order order) {
         storeData.placeOrder(order);
         return storeData.placeOrder(order);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/resource/UserResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/resource/UserResource.java
@@ -20,6 +20,7 @@ import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
@@ -43,7 +44,6 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
 @Path("/user")
-@Schema(name = "/user")
 @Produces({"application/json", "application/xml"})
 @SecuritySchemes(value = {
         @SecurityScheme(securitySchemeName = "userApiKey", type = SecuritySchemeType.APIKEY,
@@ -68,8 +68,9 @@ public class UserResource {
             @SecurityRequirement(name = "userBearerHttp")
     })
     public Response createUser(
-            @Parameter(description = "Created user object", schema = @Schema(ref = "#/components/schemas/User"),
-                       required = true) User user) {
+            @RequestBody(description = "Created user object",
+                         content = @Content(schema = @Schema(ref = "#/components/schemas/User")),
+                         required = true) User user) {
         userData.addUser(user);
         return Response.ok().entity("").build();
     }
@@ -79,7 +80,7 @@ public class UserResource {
     @APIResponse(description = "successful operation")
     @Operation(summary = "Creates list of users with given input array")
     public Response createUsersWithArrayInput(
-            @Parameter(description = "List of user object", required = true) User[] users) {
+            @RequestBody(description = "List of user object", required = true) User[] users) {
         for (User user : users) {
             userData.addUser(user);
         }
@@ -91,7 +92,7 @@ public class UserResource {
     @APIResponse(description = "successful operation")
     @Operation(summary = "Creates list of users with given input array")
     public Response createUsersWithListInput(
-            @Parameter(description = "List of user object", required = true) java.util.List<User> users) {
+            @RequestBody(description = "List of user object", required = true) java.util.List<User> users) {
         for (User user : users) {
             userData.addUser(user);
         }
@@ -111,7 +112,7 @@ public class UserResource {
             @Parameter(name = "username", description = "name that need to be deleted",
                        schema = @Schema(type = SchemaType.STRING),
                        required = true) @PathParam("username") String username,
-            @Parameter(description = "Updated user object", required = true) User user) {
+            @RequestBody(description = "Updated user object", required = true) User user) {
         userData.addUser(user);
         return Response.ok().entity("").build();
     }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
@@ -671,7 +671,7 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(s + "x-link", equalTo("test-link"));
 
         String t = "paths.'/user/id/{id}'.get.responses.'200'.links.Review.";
-        vr.body(t + "operationRef", equalTo("/db/reviews/{userName}"));
+        vr.body(t + "operationRef", equalTo("#/paths/~1reviews~1users~1{user}/get"));
         vr.body(t + "description", equalTo("The reviews provided by user"));
 
         String k = "paths.'/reviews'.post.responses.'201'.links.Review.";
@@ -749,14 +749,10 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("components.examples.review.externalValue", equalTo("http://foo.bar/examples/review-example.json"));
         vr.body("components.examples.review.x-example-object", equalTo("test-example-object"));
 
-        // Example in Parameter Content
-        vr.body("paths.'/reviews/users/{user}'.get.parameters.find{ it.name=='user'}.content.'*/*'.examples.example.value",
+        // Examples in Parameter Content
+        vr.body("paths.'/reviews/users/{user}'.get.parameters.find{ it.name=='user'}.content.'*/*'.examples.example1.value",
                 equalTo("bsmith"));
-
-        // Example in Parameter
-        vr.body("paths.'/reviews/users/{user}'.get.parameters.find{ it.name=='user'}.examples.example1.value",
-                equalTo("bsmith"));
-        vr.body("paths.'/reviews/users/{user}'.get.parameters.find{ it.name=='user'}.examples.example2.value",
+        vr.body("paths.'/reviews/users/{user}'.get.parameters.find{ it.name=='user'}.content.'*/*'.examples.example2.value",
                 equalTo("pat@example.com"));
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/PetStoreAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/PetStoreAppTest.java
@@ -57,7 +57,7 @@ public class PetStoreAppTest extends AppTestBase {
         vr.body("paths.'/pet/findByTags'.get.parameters.find{ it.name == 'tags' }.schema.externalDocs.description",
                 equalTo("Pet Types"));
         vr.body("paths.'/pet/findByTags'.get.parameters.find{ it.name == 'tags' }.schema.deprecated", equalTo(true));
-        vr.body("paths.'/store/order/{orderId}'.get.responses.'900'.schema", nullValue());
+        vr.body("paths.'/store/order/{orderId}'.get.responses.'599'.schema", nullValue());
 
         // Numerical properties
         vr.body("paths.'/pet/{petId}'.get.parameters.find{ it.name == 'petId' }.schema.maximum",


### PR DESCRIPTION
Closes #322 

There are several remaining issues reported by the OpenAPI validator [1] including:
- `/user/special` missing schemas, this is intentional to test hidden schema functionality
- `/user` POST request body encoding includes an extension `x-encoding` flagged invalid by the parser. This appears to be a bug [2]

[1] https://validator.swagger.io/
[2] https://github.com/OAI/OpenAPI-Specification/issues/3251