### PR TITLE
Extensions on methods don't cascade to responses

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/PetStoreAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/PetStoreAppTest.java
@@ -291,7 +291,6 @@ public class PetStoreAppTest extends AppTestBase {
         vr.body(opPath + ".responses.'200'", not(hasKey(X_OPERATION_EXT)));
         vr.body(opPath + ".responses.'200'", hasEntry(equalTo("x-response-ext"), equalTo("test-response-ext")));
         vr.body(opPath + ".responses.'500'", not(hasKey(X_OPERATION_EXT)));
-        vr.body(opPath + ".responses.'503'", hasEntry(equalTo(X_OPERATION_EXT), equalTo(TEST_OPERATION_EXT)));
         vr.body(opPath + ".responses.'503'.content.'application/json'",
                 hasEntry(equalTo("x-notavailable-ext"), equalTo("true")));
         vr.body(opPath + ".responses.'503'.content.'application/xml'",


### PR DESCRIPTION
There's nothing in the spec to specify that an `@Extension` annotation placed on a method should result in that extension key and value being added to the responses of the corresponding operation.

Remove the test that was asserting this behaviour.

Fixes #556