### PR TITLE
Revert "[maven-release-plugin] prepare release 3.1.1"

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.openapi</groupId>
         <artifactId>microprofile-openapi-parent</artifactId>
-        <version>3.1.1</version>
+        <version>3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-openapi-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <groupId>org.eclipse.microprofile.openapi</groupId>
     <artifactId>microprofile-openapi-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>MicroProfile OpenAPI</name>
     <description>Eclipse MicroProfile OpenAPI</description>
@@ -56,7 +56,7 @@
         <url>https://github.com/eclipse/microprofile-open-api</url>
         <connection>scm:git:https://github.com/eclipse/microprofile-open-api.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse/microprofile-open-api.git</developerConnection>
-        <tag>3.1.1</tag>
+        <tag>3.1-SNAPSHOT</tag>
     </scm>
 
     <issueManagement>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.openapi</groupId>
         <artifactId>microprofile-openapi-parent</artifactId>
-        <version>3.1.1</version>
+        <version>3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-openapi-spec</artifactId>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.openapi</groupId>
         <artifactId>microprofile-openapi-parent</artifactId>
-        <version>3.1.1</version>
+        <version>3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-openapi-spi</artifactId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.openapi</groupId>
         <artifactId>microprofile-openapi-parent</artifactId>
-        <version>3.1.1</version>
+        <version>3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-openapi-tck</artifactId>


### PR DESCRIPTION
This reverts commit 5614b7c4b1fcab83fbdc5bd8b68d7908d43e5743, which is an invalid re-release of 3.1.1 [1]


[1] https://ci.eclipse.org/microprofile/view/Release/job/MicroProfile%20Releases/824/