### PR TITLE
Update parent, add module-info, streamline OSGi annotation dependency

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,10 +28,26 @@
     <description>MicroProfile OpenAPI API :: API</description>
 
     <dependencies>
-        <dependency> 
-            <groupId>biz.aQute.bnd</groupId>
-            <artifactId>biz.aQute.bnd.annotation</artifactId>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.annotation</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>3.2.1</version>
+                    <configuration>
+                        <!-- https://github.com/checkstyle/checkstyle/issues/8240 -->
+                        <excludes>**/module-info.java</excludes>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Eclipse MicroProfile OpenAPI
+ * <p>
+ * A set of Java interfaces, annotations, and programming models which allow Java developers to natively produce OpenAPI
+ * documents from Jakarta RESTful Web Services applications.
+ */
+module org.eclipse.microprofile.openapi {
+
+    exports org.eclipse.microprofile.openapi;
+    exports org.eclipse.microprofile.openapi.annotations;
+    exports org.eclipse.microprofile.openapi.annotations.callbacks;
+    exports org.eclipse.microprofile.openapi.annotations.enums;
+    exports org.eclipse.microprofile.openapi.annotations.extensions;
+    exports org.eclipse.microprofile.openapi.annotations.headers;
+    exports org.eclipse.microprofile.openapi.annotations.info;
+    exports org.eclipse.microprofile.openapi.annotations.links;
+    exports org.eclipse.microprofile.openapi.annotations.media;
+    exports org.eclipse.microprofile.openapi.annotations.parameters;
+    exports org.eclipse.microprofile.openapi.annotations.responses;
+    exports org.eclipse.microprofile.openapi.annotations.security;
+    exports org.eclipse.microprofile.openapi.annotations.servers;
+    exports org.eclipse.microprofile.openapi.annotations.tags;
+    exports org.eclipse.microprofile.openapi.models;
+    exports org.eclipse.microprofile.openapi.models.callbacks;
+    exports org.eclipse.microprofile.openapi.models.examples;
+    exports org.eclipse.microprofile.openapi.models.headers;
+    exports org.eclipse.microprofile.openapi.models.info;
+    exports org.eclipse.microprofile.openapi.models.links;
+    exports org.eclipse.microprofile.openapi.models.media;
+    exports org.eclipse.microprofile.openapi.models.parameters;
+    exports org.eclipse.microprofile.openapi.models.responses;
+    exports org.eclipse.microprofile.openapi.models.security;
+    exports org.eclipse.microprofile.openapi.models.servers;
+    exports org.eclipse.microprofile.openapi.models.tags;
+    exports org.eclipse.microprofile.openapi.spi;
+
+    // Required for compilation, not used at runtime
+    requires static osgi.annotation;
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,9 @@
     <parent>
         <groupId>org.eclipse.microprofile</groupId>
         <artifactId>microprofile-parent</artifactId>
-        <version>2.7</version>
+        <version>3.2</version>
     </parent>
+
     <groupId>org.eclipse.microprofile.openapi</groupId>
     <artifactId>microprofile-openapi-parent</artifactId>
     <version>3.2-SNAPSHOT</version>
@@ -30,7 +31,7 @@
 
     <properties>
         <inceptionYear>2017</inceptionYear>
-        <osgi-annotation.version>1.1.1</osgi-annotation.version>
+        <osgi-annotation.version>8.1.0</osgi-annotation.version>
         <!-- Versions of TCK dependencies -->
         <rest-assured.version>4.3.0</rest-assured.version>
         <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
@@ -39,8 +40,7 @@
         <mp.rest-client-api.version>3.0.1</mp.rest-client-api.version>
         <jakarta.xml.bind-api.version>3.0.1</jakarta.xml.bind-api.version>
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
-        <biz.aQute.bnd.version>5.3.0</biz.aQute.bnd.version>
-        <version.microprofile.tck.bom>2.6</version.microprofile.tck.bom>
+        <version.microprofile.tck.bom>3.2</version.microprofile.tck.bom>
     </properties>
 
     <developers>
@@ -67,14 +67,8 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>biz.aQute.bnd</groupId>
-                <artifactId>biz.aQute.bnd.annotation</artifactId>
-                <version>${biz.aQute.bnd.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.annotation.versioning</artifactId>
+                <artifactId>osgi.annotation</artifactId>
                 <version>${osgi-annotation.version}</version>
                 <scope>provided</scope>
             </dependency>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -30,7 +30,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.annotation.versioning</artifactId>
+            <artifactId>osgi.annotation</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -42,7 +42,7 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.annotation.versioning</artifactId>
+            <artifactId>osgi.annotation</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Update parent, add module-info, streamline OSGi annotation dependency. Removes dependency on the `biz.aQute.bnd` artifact as the `osgi.annotation` should be the only one necessary.

Fixes #573 

I will also submit a follow-up PR with the changes for #574 once this is merged.