### PR TITLE
Add missing comma to `mp.openapi.schema.` configuration example

### DIFF
--- a/spec/src/main/asciidoc/microprofile-openapi-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-openapi-spec.asciidoc
@@ -159,7 +159,7 @@ escapes and indentation added for readability):
 [source, json]
 ----
 mp.openapi.schema.java.util.Date = { \
-  "name": "EpochMillis" \
+  "name": "EpochMillis", \
   "type": "number", \
   "format": "int64", \
   "description": "Milliseconds since January 1, 1970, 00:00:00 GMT" \


### PR DESCRIPTION
Fixes #568 