### PR TITLE
Validate formatting in CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,4 @@ jobs:
           cache: 'maven'
 
       - name: build with maven
-        run: mvn -B --no-transfer-progress verify javadoc:javadoc --file pom.xml
+        run: mvn -B --no-transfer-progress verify javadoc:javadoc --file pom.xml -Pvalidate-formatting

--- a/pom.xml
+++ b/pom.xml
@@ -93,4 +93,25 @@
         <module>spi</module>
     </modules>
 
+    <profiles>
+        <profile>
+            <id>validate-formatting</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.revelc.code.formatter</groupId>
+                        <artifactId>formatter-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                            <goals>
+                                <goal>validate</goal>
+                            </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
Add a profile to validate code formatting

Use this profile in the github build action

Currently, the build will autoformat the code. This change will ensure that code can't be merged if it wasn't formatted before it was committed (as we did in #580, by making a line too long when updating a comment).