### PR TITLE
Add Identifier field to License

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/info/License.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/info/License.java
@@ -41,6 +41,13 @@ public @interface License {
     String name();
 
     /**
+     * The license identifier used for the API.
+     *
+     * @return the identifier of the license
+     **/
+    String identifier() default "";
+
+    /**
      * A URL to the license used for the API. MUST be in the format of a URL.
      *
      * @return the URL of the license

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/info/License.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/info/License.java
@@ -55,6 +55,33 @@ public interface License extends Constructible, Extensible<License> {
     }
 
     /**
+     * Returns the license identifier for this License instance that is used for the API.
+     *
+     * @return the license identifier used for the API
+     **/
+    String getIdentifier();
+
+    /**
+     * Sets the license identifier for this License instance that is used for the API.
+     *
+     * @param identifier
+     *            the license identifier used for the API
+     */
+    void setIdentifier(String identifier);
+
+    /**
+     * Sets this License instance's identifier used for the API and returns this instance of License.
+     *
+     * @param identifier
+     *            the license identifier used for the API
+     * @return this License instance
+     */
+    default License identifier(String identifier) {
+        setIdentifier(identifier);
+        return this;
+    }
+
+    /**
      * Returns the URL for this License instance that is used for the API.
      *
      * @return the URL to the license used for the API

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/PetStoreApp.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/PetStoreApp.java
@@ -35,7 +35,7 @@ import jakarta.ws.rs.core.Application;
 @ApplicationPath("/")
 @OpenAPIDefinition(info = @Info(title = "Pet Store App", version = "2.0", description = "Pet Store App API",
                                 license = @License(name = "Apache 2.0",
-                                                   url = "http://www.apache.org/licenses/LICENSE-2.0.html"),
+                                                   identifier = "Apache-2.0"),
                                 contact = @Contact(name = "PetStore API Support",
                                                    url = "https://github.com/eclipse/microprofile-open-api",
                                                    email = "support@petstore.com"),

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASFactoryErrorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASFactoryErrorTest.java
@@ -72,6 +72,13 @@ public class OASFactoryErrorTest extends Arquillian {
         public License url(String url) {
             return null;
         }
+        @Override
+        public String getIdentifier() {
+            return null;
+        }
+        @Override
+        public void setIdentifier(String identifier) {
+        }
     }
 
     @Deployment

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/PetStoreAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/PetStoreAppTest.java
@@ -47,6 +47,16 @@ public class PetStoreAppTest extends AppTestBase {
                 .addPackages(true, "org.eclipse.microprofile.openapi.apps.petstore");
     }
 
+    // This test covers basic OpenAPI ingredients like licenses, if something is here instead of tested in the
+    // AirlinesApp
+    // It is likely because it is mutually exclusive with something in the AirlinesApp
+    @Test(dataProvider = "formatProvider")
+    public void testOpenAPIEssentials(String type) {
+        ValidatableResponse vr = callEndpoint(type);
+
+        vr.body("info.license.identifier", equalTo("Apache-2.0"));
+    }
+
     @Test(dataProvider = "formatProvider")
     public void testSchema(String type) {
         ValidatableResponse vr = callEndpoint(type);


### PR DESCRIPTION
This fixes #436

I'm using PetStoreApp to test this because AirLineApp tests the URL and they're mutually exclusive.