### PR TITLE
Add tests for encoding with multipart/form-data

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/annotations/media/Encoding.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/annotations/media/Encoding.java
@@ -58,7 +58,8 @@ public @interface Encoding {
 
     /**
      * Style describes how the encoding value will be serialized depending on the type of the parameter value. This
-     * property SHALL be ignored if the request body media type is not application/x-www-form-urlencoded.
+     * property SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or
+     * multipart/form-data.
      * <p>
      * Default values include: form, spaceDelimited, pipeDelimited, and deepObject.
      * </p>

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/ZepplinResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/ZepplinResource.java
@@ -13,20 +13,28 @@
 
 package org.eclipse.microprofile.openapi.apps.airlines.resources;
 
+import java.util.List;
+
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterStyle;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Encoding;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.media.SchemaProperty;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
 
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HEAD;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
@@ -69,6 +77,37 @@ public class ZepplinResource {
                required = true,
                schema = @Schema(type = SchemaType.OBJECT), style = ParameterStyle.PIPEDELIMITED)
     public Response getZepplin() {
+        return Response.ok().build();
+    }
+
+    @POST
+    @APIResponse(responseCode = "200", description = "Review posted")
+    @APIResponse(responseCode = "404", description = "Review not found")
+    @Operation(summary = "Post by Zepplin", operationId = "postZepplin")
+    @Produces("text/plain")
+    @SecurityRequirement(name = "mutualTLSScheme", scopes = "zepplinScope")
+    @Consumes("multipart/form-data")
+    public Response postZepplin(
+            @RequestBody(description = "Record of a new user to be created in the system.", required = true,
+                         content = @Content(mediaType = "multipart/form-data",
+                                            schema = @Schema(properties = {
+                                                    @SchemaProperty(name = "passenger", description = "the passanger",
+                                                                    type = SchemaType.STRING),
+                                                    @SchemaProperty(name = "allergies",
+                                                                    description = "Does the passenger have any allergies",
+                                                                    type = SchemaType.ARRAY),
+                                                    @SchemaProperty(name = "specialRequests",
+                                                                    description = "Does the passenger have any special requests",
+                                                                    type = SchemaType.OBJECT)
+                                            }),
+                                            encoding = {
+                                                    @Encoding(name = "allergies",
+                                                              allowReserved = true, explode = true,
+                                                              style = "pipeDelimited"),
+                                                    @Encoding(name = "specialRequests",
+                                                              allowReserved = true, explode = true,
+                                                              style = "spaceDelimited")
+                                            })) List<String> zeeplinUsers) {
         return Response.ok().build();
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
@@ -711,6 +711,20 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(t + "style", equalTo("form"));
         vr.body(t + "explode", equalTo(true));
         vr.body(t + "allowReserved", equalTo(true));
+
+        // Test style, explode and allowReserved when @Consumes is "multipart/form-data"
+        String allergiesEncoding =
+                "paths.'/zepplins'.post.requestBody.content.'multipart/form-data'.encoding.allergies";
+        String specialRequestsEncoding =
+                "paths.'/zepplins'.post.requestBody.content.'multipart/form-data'.encoding.specialRequests";
+
+        vr.body(allergiesEncoding + ".style", equalTo("pipeDelimited"));
+        vr.body(allergiesEncoding + ".explode", equalTo(true));
+        vr.body(allergiesEncoding + ".allowReserved", equalTo(true));
+
+        vr.body(specialRequestsEncoding + ".style", equalTo("spaceDelimited"));
+        vr.body(specialRequestsEncoding + ".explode", equalTo(true));
+        vr.body(specialRequestsEncoding + ".allowReserved", equalTo(true));
     }
 
     @Test(dataProvider = "formatProvider")


### PR DESCRIPTION
Fixes #587

Depends on #616

For the comments there was mention of "Shall be ignored if not ... www-form-urlencoded or or multipart/form-data" in several places in the spec, but only one mention of  "Shall be ignored if not ... www-form-urlencoded" in the current comments. I wasn't sure if I should only update the existing one or if I should add new ones too all. I decided there might be a good reason the other methods don't have that, but if you want them all say so and I'll add them. 