### PR TITLE
Add ZeppelinResource to application

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/JAXRSApp.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/JAXRSApp.java
@@ -56,6 +56,7 @@ import org.eclipse.microprofile.openapi.apps.airlines.resources.AirlinesResource
 import org.eclipse.microprofile.openapi.apps.airlines.resources.AvailabilityResource;
 import org.eclipse.microprofile.openapi.apps.airlines.resources.ReviewResource;
 import org.eclipse.microprofile.openapi.apps.airlines.resources.UserResource;
+import org.eclipse.microprofile.openapi.apps.airlines.resources.ZepplinResource;
 import org.eclipse.microprofile.openapi.apps.airlines.resources.bookings.BookingResource;
 
 import jakarta.ws.rs.ApplicationPath;
@@ -372,6 +373,7 @@ public class JAXRSApp extends Application {
         singletons.add(new BookingResource());
         singletons.add(new ReviewResource());
         singletons.add(new UserResource());
+        singletons.add(new ZepplinResource());
         return singletons;
     }
 


### PR DESCRIPTION
All the resource classes we expect to be scanned should be part of the application.

Fixes #631 