### PR TITLE
Depend on a single hamcrest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <osgi-annotation.version>8.1.0</osgi-annotation.version>
         <!-- Versions of TCK dependencies -->
         <rest-assured.version>4.3.0</rest-assured.version>
-        <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
+        <hamcrest.version>2.1</hamcrest.version>
         <httpclient.version>4.5.2</httpclient.version>
         <jackson.version>2.10.1</jackson.version>
         <mp.rest-client-api.version>3.0.1</mp.rest-client-api.version>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -94,13 +94,8 @@
 
          <dependency>
              <groupId>org.hamcrest</groupId>
-             <artifactId>hamcrest-all</artifactId>
-         </dependency>
-
-         <dependency>
-             <groupId>org.hamcrest</groupId>
-             <artifactId>java-hamcrest</artifactId>
-             <version>${java-hamcrest.version}</version>
+             <artifactId>hamcrest</artifactId>
+             <version>${hamcrest.version}</version>
          </dependency>
 
          <dependency>


### PR DESCRIPTION
Previously we were depending on two separate hamcrest jars and restassured was bringing in a third.

Fixes #635 