### PR TITLE
Update to microprofile-parent 2.9-RC2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 17]
+        java: [17, 21]
     name: build with jdk ${{matrix.java}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: checkout
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         name: set up jdk ${{matrix.java}}
         with:
           java-version: ${{matrix.java}}

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.microprofile</groupId>
         <artifactId>microprofile-parent</artifactId>
-        <version>2.9-RC1</version>
+        <version>2.9-RC2</version>
     </parent>
 
     <groupId>org.eclipse.microprofile.openapi</groupId>


### PR DESCRIPTION
This requires Java 17 to build due to the build plugins updated in eclipse/microprofile-parent#88