### PR TITLE
Update parent to version 2.10-RC1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.microprofile</groupId>
         <artifactId>microprofile-parent</artifactId>
-        <version>2.9</version>
+        <version>2.10-RC1</version>
     </parent>
 
     <groupId>org.eclipse.microprofile.openapi</groupId>


### PR DESCRIPTION
This fixes a bug in the parent which was causing the release build to fail with when it tried to generate the sources jar twice. See eclipse/microprofile-parent#89 for what I think was going on.

Once this is merged, I will build another MP OpenAPI RC release to check that this does fix the issues with the release build.

Fixes #641 (hopefully)