### PR TITLE
Update to MP Parent 2.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.microprofile</groupId>
         <artifactId>microprofile-parent</artifactId>
-        <version>2.10-RC1</version>
+        <version>2.10</version>
     </parent>
 
     <groupId>org.eclipse.microprofile.openapi</groupId>


### PR DESCRIPTION
The release build worked with 2.10-RC, so we've released 2.10 and should pick it up here.