### PR TITLE
Remove call to deprecated Integer constructor

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/data/PetData.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/petstore/data/PetData.java
@@ -140,7 +140,7 @@ public class PetData {
             if (status != null && !"".equals(status)) {
                 Integer count = output.get(status);
                 if (count == null) {
-                    count = new Integer(1);
+                    count = 1;
                 } else {
                     count = count.intValue() + 1;
                 }


### PR DESCRIPTION
Has been deprecated for removal since Java 9.