### PR TITLE
Make ModelConstructionTest, OASFactoryErrorTest activate OpenAPI

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
@@ -134,7 +134,9 @@ public class ModelConstructionTest extends Arquillian {
 
     @Deployment
     public static WebArchive createDeployment() {
-        return ShrinkWrap.create(WebArchive.class);
+        return ShrinkWrap.create(WebArchive.class)
+                .addPackages(true, "org.eclipse.microprofile.openapi.reader")
+                .addAsManifestResource("microprofile-reader.properties", "microprofile-config.properties");
     }
 
     // Container for matched getter, setter and builder methods

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASFactoryErrorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASFactoryErrorTest.java
@@ -83,7 +83,9 @@ public class OASFactoryErrorTest extends Arquillian {
 
     @Deployment
     public static WebArchive createDeployment() {
-        return ShrinkWrap.create(WebArchive.class);
+        return ShrinkWrap.create(WebArchive.class)
+                .addPackages(true, "org.eclipse.microprofile.openapi.reader")
+                .addAsManifestResource("microprofile-reader.properties", "microprofile-config.properties");
     }
 
     @Test(expectedExceptions = {NullPointerException.class})


### PR DESCRIPTION
Proposal to resolve https://github.com/eclipse/microprofile-open-api/issues/655

After reading https://github.com/eclipse/microprofile-open-api/issues/413, I believe these two tests should not be using empty deployment.

OpenAPI should be somehow activated, for the tested functionality to be correctly initialized. The app container have no reason to do this initialization if there is nothing that suggests OpenAPI endpoint is needed.

Currently in Wildfly, these tests only pass if they happen to run after another test from the OpenAPI TCK, where the other test activates OpenAPI for them. They fail if run alone, or if they happen to run as the first test in the module.