### PR TITLE
[3.1.x] Make ModelConstructionTest, OASFactoryErrorTest activate OpenAPI

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelConstructionTest.java
@@ -129,7 +129,9 @@ public class ModelConstructionTest extends Arquillian {
 
     @Deployment
     public static WebArchive createDeployment() {
-        return ShrinkWrap.create(WebArchive.class);
+        return ShrinkWrap.create(WebArchive.class)
+                .addPackages(true, "org.eclipse.microprofile.openapi.reader")
+                .addAsManifestResource("microprofile-reader.properties", "microprofile-config.properties");
     }
 
     // Container for matched getter, setter and builder methods

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASFactoryErrorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/OASFactoryErrorTest.java
@@ -76,7 +76,9 @@ public class OASFactoryErrorTest extends Arquillian {
 
     @Deployment
     public static WebArchive createDeployment() {
-        return ShrinkWrap.create(WebArchive.class);
+        return ShrinkWrap.create(WebArchive.class)
+                .addPackages(true, "org.eclipse.microprofile.openapi.reader")
+                .addAsManifestResource("microprofile-reader.properties", "microprofile-config.properties");
     }
 
     @Test(expectedExceptions = {NullPointerException.class})


### PR DESCRIPTION
Upstream PR: https://github.com/eclipse/microprofile-open-api/pull/657

Please see discussion on the upstream PR for the rationale.