### PR TITLE
Remove invalid `content` from TCK simpleapi.yaml test resource

### DIFF
--- a/tck/src/main/resources/simpleapi.yaml
+++ b/tck/src/main/resources/simpleapi.yaml
@@ -200,7 +200,6 @@ components:
       delete:
         responses:
           '202':
-            content: []
             description: Delete item
       parameters:
         - name: id


### PR DESCRIPTION
Fixes #663 