### PR TITLE
Add json schema dialect property

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/OpenAPI.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/OpenAPI.java
@@ -328,6 +328,36 @@ public interface OpenAPI extends Constructible, Extensible<OpenAPI> {
     void removeWebhook(String name);
 
     /**
+     * Returns the default JSON Schema dialect for schemas in this document.
+     *
+     * @return the identifier of the default schema dialect for schemas in this document
+     * @since 4.1
+     */
+    String getJsonSchemaDialect();
+
+    /**
+     * Sets the default JSON Schema dialect for schemas in this document.
+     *
+     * @param jsonSchemaDialect
+     *            the identifier of the default schema dialect for schemas in this document
+     * @since 4.1
+     */
+    void setJsonSchemaDialect(String jsonSchemaDialect);
+
+    /**
+     * Sets the default JSON Schema dialect for schemas in this document.
+     *
+     * @param jsonSchemaDialect
+     *            the identifier of the default schema dialect for schemas in this document
+     * @return the current OpenAPI object
+     * @since 4.1
+     */
+    default OpenAPI jsonSchemaDialect(String jsonSchemaDialect) {
+        setJsonSchemaDialect(jsonSchemaDialect);
+        return this;
+    }
+
+    /**
      * Returns the components property from an OpenAPI instance.
      *
      * @return schemas used in the specification

--- a/api/src/main/java/org/eclipse/microprofile/openapi/models/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/openapi/models/package-info.java
@@ -40,6 +40,6 @@
  * </pre>
  */
 
-@org.osgi.annotation.versioning.Version("2.1")
+@org.osgi.annotation.versioning.Version("2.2")
 @org.osgi.annotation.versioning.ProviderType
 package org.eclipse.microprofile.openapi.models;

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/reader/MyOASModelReaderImpl.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/reader/MyOASModelReaderImpl.java
@@ -308,6 +308,7 @@ public class MyOASModelReaderImpl implements OASModelReader {
                 .externalDocs(OASFactory.createObject(ExternalDocumentation.class)
                         .description("instructions for how to deploy this app")
                         .url("https://github.com/microservices-api/oas3-airlines/blob/master/README.md"))
+                .jsonSchemaDialect("https://json-schema.org/draft/2020-12/schema")
                 .addWebhook("bookingEvent", OASFactory.createPathItem()
                         .PUT(OASFactory.createOperation()
                                 .summary("Notifies that a booking has been created")

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelReaderAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ModelReaderAppTest.java
@@ -427,4 +427,10 @@ public class ModelReaderAppTest extends AppTestBase {
 
         vr.body("paths.'/zepplins'.delete.requestBody.content", notNullValue());
     }
+
+    @Test(dataProvider = "formatProvider")
+    public void testSchemaDialect(String type) {
+        ValidatableResponse vr = callEndpoint(type);
+        vr.body("jsonSchemaDialect", equalTo("https://json-schema.org/draft/2020-12/schema"));
+    }
 }


### PR DESCRIPTION
Add `jsonSchemaDialect` to the model ~and annotations~.

In the model test, I've put the JSON Schema 2020-12 dialect and as it's in the model, I expect it to be passed through as-is.

~In the annotation test, I've put the OAS default schema dialect since I don't think we can reasonably rely on an implementation to have well defined behaviour for any other values. An implementation could reasonably do any of the following:~

- ~generate schemas in the specified dialect~
- ~generate schemas in the OAS default dialect and set `$schema` in all of them, overriding the default set at the top level~
- ~report an error and generate nothing~

Fixes #660