### PR TITLE
Bump microprofile-parent from 2.11 to 2.12-RC1, fix SCM tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.microprofile</groupId>
         <artifactId>microprofile-parent</artifactId>
-        <version>2.11</version>
+        <version>2.12-RC1</version>
     </parent>
 
     <groupId>org.eclipse.microprofile.openapi</groupId>
@@ -58,7 +58,7 @@
         <url>https://github.com/eclipse/microprofile-open-api</url>
         <connection>scm:git:https://github.com/eclipse/microprofile-open-api.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse/microprofile-open-api.git</developerConnection>
-        <tag>3.1-SNAPSHOT</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
Update to the latest 2.x MP parent RC. This was tested with the TCK against smallrye-open-api without any problems.

The `scm/tag` has been incorrectly set to old snapshot versions since around the 2.0 release. This PR fixes it to be `HEAD` outside of releases.