### PR TITLE
[issue-713] - Add a test to the TCKs in order to verify the usage of the "@ExternalDocumentation" annotation

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/scanconfig/a/AResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/scanconfig/a/AResource.java
@@ -15,13 +15,19 @@
  */
 package org.eclipse.microprofile.openapi.apps.scanconfig.a;
 
+import org.eclipse.microprofile.openapi.annotations.ExternalDocumentation;
+
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
 @Path("a")
+@ExternalDocumentation(description = "Find more information about this application",
+                       url = "https://github.com/microprofile/microprofile-open-api/blob/main/tck/src/main/java/org/eclipse/microprofile/openapi/apps/scanconfig/ScanConfigApplication.java")
 public class AResource {
 
     @GET
+    @ExternalDocumentation(description = "Find more information about this application resource",
+                           url = "https://github.com/microprofile/microprofile-open-api/blob/main/tck/src/main/java/org/eclipse/microprofile/openapi/apps/scanconfig/a/AResource.java")
     public String get() {
         return "a";
     }

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ExternalDocumentationAnnotationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/ExternalDocumentationAnnotationTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.openapi.tck;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.eclipse.microprofile.openapi.apps.scanconfig.ScanConfigApplication;
+import org.eclipse.microprofile.openapi.apps.scanconfig.a.AResource;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import io.restassured.response.ValidatableResponse;
+
+/**
+ * Verify usage of the {@code @ExternalDocumentation} annotation.
+ */
+public class ExternalDocumentationAnnotationTest extends AppTestBase {
+
+    @Deployment(name = "externalDocs-test", testable = false)
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class, "externalDocs-test.war")
+                .addClasses(ScanConfigApplication.class, AResource.class);
+    }
+
+    /**
+     * Check that the {@code externalDocs} element is present in the generated OpenAPI document when the
+     * {@code @ExternalDocumentation} annotation is used on a resource method definition.
+     *
+     * @param type
+     *            Type of the OpenAPI output format
+     */
+    @Test(dataProvider = "formatProvider")
+    public void testExternalDocumentationAnnotationOnMethod(String type) {
+        ValidatableResponse vr = callEndpoint(type);
+
+        vr.body("paths.'/a'.get.externalDocs.description",
+                equalTo("Find more information about this application resource"));
+        vr.body("paths.'/a'.get.externalDocs.url", equalTo(
+                "https://github.com/microprofile/microprofile-open-api/blob/main/tck/src/main/java/org/eclipse/microprofile/openapi/apps/scanconfig/a/AResource.java"));
+    }
+}


### PR DESCRIPTION
We recently found [an issue in the SmallRye OpenAPI implementation](https://github.com/smallrye/smallrye-open-api/issues/2386), which reveals missing test coverage for the `@ExternalDocumentation` annotation usage in the MicroProfile OpenAPI TCKs.

This PR provides a new test to cover some basic cases.

Resolves #713 