### PR TITLE
Align bnd annotation version with parent

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>biz.aQute.bnd</groupId>
             <artifactId>biz.aQute.bnd.annotation</artifactId>
-            <version>7.0.0</version>
+            <version>${version.plugin.bnd}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The parent provides and sets the versions for the BND plugins. Use the same version here where we're adding the annotations as a build-time dependency.